### PR TITLE
fix:#51 SignIn 및 SignUp 페이지의 폼 타입을 zod에서 interface로 변경하여 타입 정의를 명확히 함

### DIFF
--- a/src/app/(pages)/signIn/page.tsx
+++ b/src/app/(pages)/signIn/page.tsx
@@ -8,12 +8,14 @@ import { PLACEHOLDER_EMAIL, PLACEHOLDER_PASSWORD } from '@/constants/placeholder
 import { PEOPLE, SIGNUP } from '@/constants/paths';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { signInSchema } from '@/lib/schemas/signinSchema';
-import { z } from 'zod';
 import Link from 'next/link';
 import Image from 'next/image';
 import { toast } from 'react-toastify';
 
-export type SignInFormType = z.infer<typeof signInSchema>;
+export interface SignInFormType {
+  email: string;
+  password: string;
+}
 
 const SignIn = () => {
   const { register, handleSubmit, formState } = useForm<SignInFormType>({

--- a/src/app/(pages)/signUp/page.tsx
+++ b/src/app/(pages)/signUp/page.tsx
@@ -20,11 +20,15 @@ import {
 import { PEOPLE } from '@/constants/paths';
 import { useState } from 'react';
 import { signUpSchema } from '@/lib/schemas/signupSchema';
-import { z } from 'zod';
 import Image from 'next/image';
 import { toast } from 'react-toastify';
 
-export type SignUpFormType = z.infer<typeof signUpSchema>;
+export interface SignUpFormType {
+  email: string;
+  password: string;
+  nickname: string;
+  passwordCheck: string;
+}
 
 const SignUp = () => {
   const [isNicknameChecked, setIsNicknameChecked] = useState<boolean>(false);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #51 

<br>

## 📝 작업 내용

> 빌드에러를 고치기 위한 코드 수정
> zod에서 제공하는 타입 추론 메서드를 직접 타입 선언으로 변경