### PR TITLE
Bugfix#69 로그아웃 핸들러에서 (event === 'SIGNED_OUT')일때 적용되던 로그아웃 함수를 제거

### DIFF
--- a/src/components/nav/LeftNavBar.tsx
+++ b/src/components/nav/LeftNavBar.tsx
@@ -6,24 +6,22 @@ import { Users, CalendarBlank, SignOut, Bell } from '@phosphor-icons/react';
 import { useAuthStore } from '@/store/zustand/store';
 import Image from 'next/image';
 import { usePathname } from 'next/navigation';
+import { toast } from 'react-toastify';
 
 const LeftNavBar = () => {
   const { user, isSignIn, signOut } = useAuthStore();
- 
+
   const pathName = usePathname();
   const page = pathName.slice(1);
 
   const logoutHandler = () => {
     if (!isSignIn) {
-      alert('이미 로그아웃 상태입니다.');
-      return;
-    } else {
-      const ok = confirm('정말 로그아웃 하시겠습니까?');
-      if (ok) {
-        signOut();
-      }
+      toast.info('이미 로그아웃 상태입니다.');
       return;
     }
+    const ok = confirm('정말 로그아웃 하시겠습니까?');
+    if (!ok) return;
+    signOut();
   };
 
   return (

--- a/src/store/zustand/store.ts
+++ b/src/store/zustand/store.ts
@@ -34,7 +34,7 @@ export const useAuthStore = create<AuthStateType>()(
 
 // 로그인 시 탭 전환 등으로 인해 중복 알림이 발생하지 않도록 localStorage를 사용해 제어
 export const AuthStateChangeHandler = () => {
-  const { setUser, signOut } = useAuthStore.getState();
+  const { setUser } = useAuthStore.getState();
 
   const { data: unsubscribe } = supabase.auth.onAuthStateChange((event, session) => {
     const alreadySignIn = localStorage.getItem('alreadySignIn');
@@ -47,7 +47,6 @@ export const AuthStateChangeHandler = () => {
         toast.success(`로그인되었습니다.'내 사람' 페이지로 이동합니다.`);
       }
     } else if (event === 'SIGNED_OUT') {
-      signOut(); // 사용자 정보 null로 초기화, isSignIn 을 false로 변경
       localStorage.removeItem('alreadySignIn');
     }
   });


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- ex) #69 

<br>

## 📝 작업 내용

> people페이지에서 로그아웃 시 무한 로딩 되는 이슈를 수정하였습니다. 

<br>

## 🖼 스크린샷

<br>

## 💬리뷰 요구사항
