### PR TITLE
fix:#89 구글 및 카카오 로그인 리다이렉트 URL을 로컬에서 배포된 URL로 변경

### DIFF
--- a/src/app/api/supabase/service.ts
+++ b/src/app/api/supabase/service.ts
@@ -210,7 +210,7 @@ export const signInWithGoogle = async () => {
   const { error } = await supabase.auth.signInWithOAuth({
     provider: 'google',
     options: {
-      redirectTo: 'http://localhost:3000/people',
+      redirectTo: 'https://saram-byeol.vercel.app/people',
       queryParams: {
         access_type: 'offline',
         prompt: 'consent',
@@ -224,7 +224,7 @@ export const signInWithKakao = async () => {
   const { error } = await supabase.auth.signInWithOAuth({
     provider: 'kakao',
     options: {
-      redirectTo: 'http://localhost:3000/people',
+      redirectTo: 'https://saram-byeol.vercel.app/people',
       queryParams: {
         access_type: 'offline',
         prompt: 'consent',


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #89 

<br>

## 📝 작업 내용

> 구글 및 카카오 로그인 리다이렉트 URL을 로컬에서 배포된 URL로 변경

