### PR TITLE
Refactor/#92 onauthstatechange to root

### DIFF
--- a/src/app/(pages)/(nav)/people/page.tsx
+++ b/src/app/(pages)/(nav)/people/page.tsx
@@ -2,7 +2,7 @@
 
 import ContactList from '@/components/contacts/ContactList';
 import PeopleDetailPanel from '@/components/contactDetail/PeopleDetailPanel';
-import { AuthStateChangeHandler, useAuthStore } from '@/store/zustand/store';
+import { useAuthStore } from '@/store/zustand/store';
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { SIGNIN } from '@/constants/paths';
@@ -12,14 +12,6 @@ const People = () => {
   const [hasMounted, setHasMounted] = useState(false);
   const isSignIn = useAuthStore((state) => state.isSignIn);
   const router = useRouter();
-
-  //onAuthStateChange호출 로직
-  useEffect(() => {
-    const { subscription } = AuthStateChangeHandler();
-    return () => {
-      subscription.unsubscribe();
-    };
-  }, []);
 
   // 마운트 이후에만 렌더링
   useEffect(() => {

--- a/src/app/api/supabase/service.ts
+++ b/src/app/api/supabase/service.ts
@@ -210,7 +210,7 @@ export const signInWithGoogle = async () => {
   const { error } = await supabase.auth.signInWithOAuth({
     provider: 'google',
     options: {
-      redirectTo: 'http://localhost:3000/people',
+      redirectTo: 'https://saram-byeol.vercel.app/people',
       queryParams: {
         access_type: 'offline',
         prompt: 'consent',
@@ -224,7 +224,7 @@ export const signInWithKakao = async () => {
   const { error } = await supabase.auth.signInWithOAuth({
     provider: 'kakao',
     options: {
-      redirectTo: 'http://localhost:3000/people',
+      redirectTo: 'https://saram-byeol.vercel.app/people',
       queryParams: {
         access_type: 'offline',
         prompt: 'consent',

--- a/src/app/api/supabase/service.ts
+++ b/src/app/api/supabase/service.ts
@@ -3,6 +3,7 @@ import { supabase } from '@/app/api/supabase/client';
 import { InsertNewPlansType, PlansType } from '@/types/plans';
 import { CONTACTS, PLANS, USERS } from '@/constants/supabaseTable';
 import { useAuthStore } from '@/store/zustand/store';
+import { OAUTH_REDIRECT_URL } from '@/constants/redirecturl';
 
 export const getContacts = async (userId: string): Promise<ContactItemType[]> => {
   try {
@@ -210,7 +211,7 @@ export const signInWithGoogle = async () => {
   const { error } = await supabase.auth.signInWithOAuth({
     provider: 'google',
     options: {
-      redirectTo: 'https://saram-byeol.vercel.app/people',
+      redirectTo: `${OAUTH_REDIRECT_URL}/people`,
       queryParams: {
         access_type: 'offline',
         prompt: 'consent',
@@ -224,7 +225,7 @@ export const signInWithKakao = async () => {
   const { error } = await supabase.auth.signInWithOAuth({
     provider: 'kakao',
     options: {
-      redirectTo: 'https://saram-byeol.vercel.app/people',
+      redirectTo: `${OAUTH_REDIRECT_URL}/people`,
       queryParams: {
         access_type: 'offline',
         prompt: 'consent',

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import './globals.css';
 import { Providers } from '@/app/providers';
 import { ToastContainer } from 'react-toastify';
 import localFont from 'next/font/local';
+import OnAuthStateChange from '@/components/onauthstatechange/OnAuthStateChange';
 
 export const metadata: Metadata = {
   title: '사람 별',
@@ -25,6 +26,7 @@ export default function RootLayout({
     <html lang='ko' className={`${pretendard.variable}`}>
       <body className={pretendard.className}>
         <Providers>
+          <OnAuthStateChange />
           {children}
           <ToastContainer
             position='top-right'

--- a/src/components/onauthstatechange/OnAuthStateChange.tsx
+++ b/src/components/onauthstatechange/OnAuthStateChange.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { AuthStateChangeHandler } from '@/store/zustand/store';
+import { useEffect } from 'react';
+
+//onAuthStateChange호출 로직
+const OnAuthStateChange = () => {
+  useEffect(() => {
+    const { subscription } = AuthStateChangeHandler();
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, []);
+
+  return null;
+};
+
+export default OnAuthStateChange;

--- a/src/constants/redirecturl.ts
+++ b/src/constants/redirecturl.ts
@@ -1,0 +1,1 @@
+export const OAUTH_REDIRECT_URL = 'https://saram-byeol.vercel.app';

--- a/src/hooks/useSignin.ts
+++ b/src/hooks/useSignin.ts
@@ -1,21 +1,16 @@
 import { signInUser } from '@/app/api/supabase/service';
 import { SignInFormType } from '@/components/signin/SigninForm';
 import { PEOPLE } from '@/constants/paths';
-import { useAuthStore } from '@/store/zustand/store';
 import { useRouter } from 'next/navigation';
 import { toast } from 'react-toastify';
 
 export const useSignin = () => {
   const router = useRouter();
-  const setUser = useAuthStore((state) => state.setUser);
 
   //로그인 기능 핸들러
   const SignInHandler = async (value: SignInFormType) => {
     const { data, error } = await signInUser(value);
     if (data.session) {
-      localStorage.setItem('alreadySignIn', 'true');
-      toast.success(`로그인되었습니다.'내 사람' 페이지로 이동합니다.`);
-      setUser(data.session.user);
       router.push(PEOPLE);
     } else if (error) {
       toast.warning('아이디 또는 비밀번호를 확인해주세요.');


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #92 

<br>

## 📝 작업 내용

> 기존에 people페이지에 있던 onAuthStateChange를 호출하는 useEffect를 컴포넌트로 분리한 후 RootLayout에서 provider형식으로 관리하는 리팩토링
