### PR TITLE
Bugfix/#014 sign in user plans

### DIFF
--- a/src/app/(pages)/(nav)/calendar/page.tsx
+++ b/src/app/(pages)/(nav)/calendar/page.tsx
@@ -46,6 +46,7 @@ export default function Calendar() {
     <div className='flex flex-col gap-4 p-4 md:flex-row'>
       <div className='md:flex-grow'>
         <MainCalendar
+          user={user}
           setSelectPlan={(plan) => {
             setSelectPlan(plan);
             setShowUpcoming(false);

--- a/src/app/api/supabase/service.ts
+++ b/src/app/api/supabase/service.ts
@@ -2,8 +2,8 @@ import { ContactDetailType, ContactItemType, ContactWithPlansDetailType } from '
 import { supabase } from '@/app/api/supabase/client';
 import { InsertNewPlansType, PlansType } from '@/types/plans';
 import { CONTACTS, PLANS, USERS } from '@/constants/supabaseTable';
-import { useAuthStore } from '@/store/zustand/store';
 import { OAUTH_REDIRECT_URL } from '@/constants/redirecturl';
+import { User } from '@supabase/supabase-js';
 
 export const getContacts = async (userId: string): Promise<ContactItemType[]> => {
   try {
@@ -96,9 +96,7 @@ export const emailDuplicateTest = async (email: string) => {
 };
 
 // 매 달의 plans 데이터 가져오기
-export const getMonthlyPlans = async (year: number, month: number): Promise<PlansType[]> => {
-  const user = useAuthStore.getState().user;
-
+export const getMonthlyPlans = async (user: User, year: number, month: number): Promise<PlansType[]> => {
   if (!user) {
     throw new Error('로그인된 사용자가 없습니다.');
   }

--- a/src/components/calendar/MainCalendar.tsx
+++ b/src/components/calendar/MainCalendar.tsx
@@ -11,6 +11,7 @@ import { useGetHolidays } from '@/hooks/queries/useGetHolidays';
 import { holidayStyle } from '@/lib/utils/calendarStyle';
 import CalendarPopOver from '@/components/calendar/popOver/CalendarPopOver';
 import { useGetSelectPlan } from '@/hooks/queries/useGetSelectPlan';
+import { User } from '@supabase/supabase-js';
 
 // 드래그 이벤트 타입
 interface Props {
@@ -20,6 +21,7 @@ interface Props {
 }
 
 interface MainCalendarProps {
+  user: User | null;
   setSelectPlan: React.Dispatch<React.SetStateAction<PlansType[] | null>>;
   CustomToolbarProps: {
     onShowUpcomingPlans: () => void;
@@ -35,7 +37,7 @@ const localizer = dateFnsLocalizer({
   locales: {},
 });
 
-const MainCalendar = ({ setSelectPlan, CustomToolbarProps }: MainCalendarProps) => {
+const MainCalendar = ({ setSelectPlan, CustomToolbarProps, user }: MainCalendarProps) => {
   const [moment, setMoment] = useState(new Date()); //해당 달
   const [selectedDate, setSelectedDate] = useState<Date | null>(null); //선택한 셀 날짜
   const [isPopOverOpen, setIsPopOverOpen] = useState(false); //팝오버 오픈 여부
@@ -46,7 +48,7 @@ const MainCalendar = ({ setSelectPlan, CustomToolbarProps }: MainCalendarProps) 
   const { data: selectedPlanData, refetch } = useGetSelectPlan(selectedPlanId ?? '');
   const { mutate: updateEvent } = useUpadateEventMutate();
   const { data: holidays } = useGetHolidays(String(calendarYear));
-  const { data: events, isPending, isError, error } = useGetCalendarPlans(calendarYear, moment);
+  const { data: events, isPending, isError, error } = useGetCalendarPlans(user, calendarYear, moment);
 
   // 약속 + 공휴일
   const combinedEvents: CalendarEventType[] = [

--- a/src/hooks/queries/useGetCalendarPlans.ts
+++ b/src/hooks/queries/useGetCalendarPlans.ts
@@ -1,15 +1,21 @@
 import { getMonthlyPlans } from '@/app/api/supabase/service';
 import { QUERY_KEY } from '@/constants/queryKey';
 import { CalendarEventType, PlansType } from '@/types/plans';
+import { User } from '@supabase/supabase-js';
 import { useQuery } from '@tanstack/react-query';
 
-export const useGetCalendarPlans = (year: number, monthDate: Date) => {
+export const useGetCalendarPlans = (user: User | null, year: number, monthDate: Date) => {
   const month = monthDate.getMonth() + 1; // Date 객체 -> 숫자 전환
 
   return useQuery<CalendarEventType[]>({
-    queryKey: [QUERY_KEY.PLANS, year, month], //달마다 캐싱
+    queryKey: [QUERY_KEY.PLANS, user?.id, year, month], //달마다 캐싱
+    enabled: !!user,
     queryFn: async () => {
-      const plans: PlansType[] = await getMonthlyPlans(year, month); // supabase에서 plans 데이터 가져오기
+      if (!user) {
+        throw new Error('로그인된 사용자가 없습니다.');
+      }
+
+      const plans: PlansType[] = await getMonthlyPlans(user, year, month); // supabase에서 plans 데이터 가져오기
 
       // 캘린더에 적용되도록 데이터 가공하기
       const events: CalendarEventType[] = plans.map((plan) => ({


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #104

<br>

## 📝 작업 내용

> 새로운 아이디로 로그인 시 해당 유저의 약속이 캘린더에 나타납니다.
이전 아이디의 약속이 캘린더에서 보이지 않습니다.
쿼리 키에 현재 로그인한 유저의 아이디를 추가하였습니다.

<br>

## 🖼 스크린샷
![PR](https://github.com/user-attachments/assets/22291da7-371d-45c6-b395-dd3ad8426dec)


<br>

## 💬리뷰 요구사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- 캘린더 데이터가 로그인한 사용자별로 조회되도록 개선되었습니다.
- **버그 수정**
	- 로그인하지 않은 경우 캘린더 데이터가 불러와지지 않도록 처리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->