### PR TITLE
Feature/#109 upcoming plans length

### DIFF
--- a/src/app/(pages)/(nav)/calendar/page.tsx
+++ b/src/app/(pages)/(nav)/calendar/page.tsx
@@ -43,7 +43,7 @@ export default function Calendar() {
   if (!hasMounted || !isSignIn) return null;
 
   return (
-    <div className='flex flex-col gap-4 p-4 md:flex-row'>
+    <div className='flex flex-col gap-4 md:flex-row'>
       <div className='md:flex-grow'>
         <MainCalendar
           user={user}
@@ -98,7 +98,7 @@ export default function Calendar() {
           </>
         ) : selectPlan ? (
           <>
-            <h2 className='mb-4 text-xl font-bold'>약속 디테일</h2>
+            <h2 className='mb-4 text-xl font-bold'>약속 상세</h2>
             <div className='p-12'>
               <SelectPlan
                 plans={selectPlan}

--- a/src/components/calendar/UpcomingPlanButton.tsx
+++ b/src/components/calendar/UpcomingPlanButton.tsx
@@ -1,11 +1,26 @@
-import React from 'react';
+import { getUserPlans } from '@/app/api/supabase/service';
+import { useAuthStore } from '@/store/zustand/store';
+import React, { useEffect, useState } from 'react';
 
 const UpcomingPlanButton = ({ onClick }: { onClick: () => void }) => {
+  const user = useAuthStore((state) => state.user);
+  const [upcomingCount, setUpcomingCount] = useState(0);
+
+  useEffect(() => {
+    const fetchPlans = async () => {
+      if (user?.id) {
+        const upcomingPlans = await getUserPlans(user.id);
+        setUpcomingCount(upcomingPlans.length);
+      }
+    };
+    fetchPlans();
+  }, [user?.id]);
+
   return (
     <div>
       <button onClick={onClick} className='mr-[24px] rounded-md border-[1px] px-[20px] py-[12px] text-[14px] font-bold'>
         다가오는 약속
-        {/* 다가오는 약속 갯수 추가 */}
+        <span className='m-1 rounded-full bg-black px-1 text-white'>{upcomingCount}</span>
       </button>
     </div>
   );

--- a/src/components/calendar/UpcomingPlanButton.tsx
+++ b/src/components/calendar/UpcomingPlanButton.tsx
@@ -4,13 +4,13 @@ import React, { useEffect, useState } from 'react';
 
 const UpcomingPlanButton = ({ onClick }: { onClick: () => void }) => {
   const user = useAuthStore((state) => state.user);
-  const [upcomingCount, setUpcomingCount] = useState(0);
+  const [upcomingCount, setUpcomingCount] = useState<number | null>(null);
 
   useEffect(() => {
     const fetchPlans = async () => {
       if (user?.id) {
         const upcomingPlans = await getUserPlans(user.id);
-        setUpcomingCount(upcomingPlans.length);
+        setUpcomingCount(upcomingPlans.length); // 데이터 도착한 후에만 업데이트
       }
     };
     fetchPlans();
@@ -20,7 +20,9 @@ const UpcomingPlanButton = ({ onClick }: { onClick: () => void }) => {
     <div>
       <button onClick={onClick} className='mr-[24px] rounded-md border-[1px] px-[20px] py-[12px] text-[14px] font-bold'>
         다가오는 약속
-        <span className='m-1 rounded-full bg-black px-1 text-white'>{upcomingCount}</span>
+        <span className='m-1 rounded-full bg-black px-1 text-white'>
+          {upcomingCount !== null ? upcomingCount : '-'}
+        </span>
       </button>
     </div>
   );


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #109 

<br>

## 📝 작업 내용

> '다가오는 버튼'에 현재 다가오는 약속 개수를 나타냅니다.

<br>

## 🖼 스크린샷
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/bab4037d-cfe3-4581-92d8-073f4fbb34da" />

<br>

## 💬리뷰 요구사항

> 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **스타일**
  - 캘린더 페이지의 메인 컨테이너 패딩이 제거되어 레이아웃 간격이 변경되었습니다.
  - 선택된 약속 상세 섹션의 제목이 "약속 디테일"에서 "약속 상세"로 변경되었습니다.

- **신규 기능**
  - 다가오는 약속 버튼에 사용자의 다가오는 약속 개수가 표시됩니다. (없을 경우 대시(-)로 표시)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->