### PR TITLE
Bugfix/#102 social login redirect error

### DIFF
--- a/src/app/api/supabase/service.ts
+++ b/src/app/api/supabase/service.ts
@@ -3,7 +3,7 @@ import { supabase } from '@/app/api/supabase/client';
 import { InsertNewPlansType, PlansType } from '@/types/plans';
 import { CONTACTS, PLANS, USERS } from '@/constants/supabaseTable';
 import { useAuthStore } from '@/store/zustand/store';
-import { OAUTH_REDIRECT_URL } from '@/constants/redirecturl';
+import { REDIRECT_TO } from '@/constants/redirecturl';
 
 export const getContacts = async (userId: string): Promise<ContactItemType[]> => {
   try {
@@ -211,7 +211,8 @@ export const signInWithGoogle = async () => {
   const { error } = await supabase.auth.signInWithOAuth({
     provider: 'google',
     options: {
-      redirectTo: `${OAUTH_REDIRECT_URL}/people`,
+      redirectTo: REDIRECT_TO,
+      // 매번 로그인 시 계정 선택 및 인증 정보 재입력 유도
       queryParams: {
         access_type: 'offline',
         prompt: 'consent',
@@ -225,10 +226,10 @@ export const signInWithKakao = async () => {
   const { error } = await supabase.auth.signInWithOAuth({
     provider: 'kakao',
     options: {
-      redirectTo: `${OAUTH_REDIRECT_URL}/people`,
+      redirectTo: REDIRECT_TO,
+      // 매번 로그인 인증 정보 재입력 유도
       queryParams: {
-        access_type: 'offline',
-        prompt: 'consent',
+        auth_type: 'reauthenticate',
       },
     },
   });

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -3,14 +3,12 @@
 import { useEffect } from 'react';
 import { supabase } from '@/app/api/supabase/client';
 import { useRouter } from 'next/navigation';
-import { useAuthStore } from '@/store/zustand/store';
 
 // 컴포넌트 마운트 시 현재 로그인 세션 확인
 // 세션이 있으면 '/people'로
 // 세션이 없으면 '/signin'으로
 const AuthCallbackPage = () => {
   const router = useRouter();
-  const setUser = useAuthStore((state) => state.setUser);
 
   useEffect(() => {
     supabase.auth.getSession().then(({ data: { session } }) => {
@@ -20,7 +18,7 @@ const AuthCallbackPage = () => {
         router.replace('/signin');
       }
     });
-  }, [router, setUser]);
+  }, [router]);
 
   return (
     <div className='flex h-screen w-screen items-center justify-center'>

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useEffect } from 'react';
+import { supabase } from '@/app/api/supabase/client';
+import { useRouter } from 'next/navigation';
+import { useAuthStore } from '@/store/zustand/store';
+
+// 컴포넌트 마운트 시 현재 로그인 세션 확인
+// 세션이 있으면 '/people'로
+// 세션이 없으면 '/signin'으로
+const AuthCallbackPage = () => {
+  const router = useRouter();
+  const setUser = useAuthStore((state) => state.setUser);
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (session) {
+        router.replace('/people');
+      } else {
+        router.replace('/signin');
+      }
+    });
+  }, [router, setUser]);
+
+  return (
+    <div className='flex h-screen w-screen items-center justify-center'>
+      <p>로그인 처리 중…</p>
+    </div>
+  );
+};
+
+export default AuthCallbackPage;

--- a/src/components/signin/SigninSocial.tsx
+++ b/src/components/signin/SigninSocial.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { signInWithGoogle, signInWithKakao } from '@/app/api/supabase/service';
 import Image from 'next/image';
 import React from 'react';
@@ -15,7 +17,7 @@ const SigninSocial = () => {
   const kakaoSignin = async () => {
     const error = await signInWithKakao();
 
-    if (error) toast.warning('로그인 중 오류가 발생했습니다. 새로고침 후 다시 로그인해주세요.');
+    if (error) toast.warning('카카오 로그인에 실패했습니다. 새로고침 후 다시 시도해주세요.');
   };
 
   return (

--- a/src/constants/redirecturl.ts
+++ b/src/constants/redirecturl.ts
@@ -1,1 +1,7 @@
-export const OAUTH_REDIRECT_URL = 'https://saram-byeol.vercel.app';
+// 개발 환경(pnpm dev)에서는 localhost로 리다이렉션
+// 배포 환경(pnpm start 또는 배포 사이트)에서는 실제 도메인으로 리다이렉션
+const isDev = process.env.NODE_ENV === 'development';
+
+const BASE_URL = isDev ? process.env.NEXT_PUBLIC_LOCAL_BASE_URL : process.env.NEXT_PUBLIC_PROJECT_BASE_URL;
+
+export const REDIRECT_TO = `${BASE_URL}/auth/callback`;

--- a/src/store/zustand/store.ts
+++ b/src/store/zustand/store.ts
@@ -39,12 +39,13 @@ export const AuthStateChangeHandler = () => {
   const { data: unsubscribe } = supabase.auth.onAuthStateChange((event, session) => {
     const alreadySignIn = localStorage.getItem('alreadySignIn');
 
-    if (event === 'SIGNED_IN' && session) {
-      setUser(session.user); // 사용자 정보 저장, isSignIn 을 true로 변경
+    if ((event === 'INITIAL_SESSION' || event === 'SIGNED_IN') && session) {
+      setUser(session.user);
 
-      if (!alreadySignIn) {
+      // 토스트는 실제 로그인 액션 때만 띄우기
+      if (event === 'SIGNED_IN' && !alreadySignIn) {
         localStorage.setItem('alreadySignIn', 'true');
-        toast.success(`로그인되었습니다.'내 사람' 페이지로 이동합니다.`);
+        toast.success(`로그인되었습니다. '내 사람' 페이지로 이동합니다.`);
       }
     } else if (event === 'SIGNED_OUT') {
       localStorage.removeItem('alreadySignIn');


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- ex) #102 

<br>

## 📝 작업 내용

> - 소셜로그인을 2번 해야만 로그인이되는 현상을 수정했습니다.
> - 일반 로그인과 달리 소셜 로그인은 Supabase에서 OAuth 리다이렉션을 통해 세션을 설정하는 방식이기 때문에,
리다이렉션 직후 세션이 완전히 반영되기 전에 페이지 전환이 발생해서 발생한 오류였습니다.

> - 소셜 로그인 후 리다이렉션을 조정하였습니다.
> - 리다이렉션 URL을 동적으로 생성하여, 개발 환경(pnpm dev)에서는 localhost로, 배포 환경(pnpm start 또는 배포 사이트)에서는 실제 도메인으로 리다이렉션할 수 있게 설정했습니다.
> - 소셜로그인 시 로딩이 발생하는데 추후 로딩 스피너 통일할 때 같이 작업할 예정입니다.

<br>

## 🖼 스크린샷
![bandicam2025-04-1813-08-05-950-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/31645600-bceb-4ec3-9cf5-841ab8c08937)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- 인증 콜백 처리를 위한 새로운 페이지가 추가되어, 로그인 후 자동으로 적절한 경로로 이동합니다.
- **버그 수정**
	- 카카오 로그인 실패 시 더 구체적인 오류 메시지가 표시됩니다.
	- 로그인 성공 알림이 초기 세션 복원 시에는 표시되지 않고, 명시적 로그인 시에만 나타나도록 수정되었습니다.
- **개선 사항**
	- OAuth 리다이렉트 URL이 환경에 따라 동적으로 결정되어, 개발 및 운영 환경 모두에서 올바르게 동작합니다.
	- Google 및 Kakao 로그인 시 항상 계정 선택 및 재인증을 요구하도록 OAuth 흐름이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->