### PR TITLE
Bugfix/#118 calendar plans detail error

### DIFF
--- a/src/app/(pages)/(nav)/calendar/page.tsx
+++ b/src/app/(pages)/(nav)/calendar/page.tsx
@@ -149,6 +149,12 @@ export default function Calendar() {
   };
 
   const moveEventsHandler = ({ event, start, end }: DragEventType) => {
+    updateLocalEvent({
+      id: event.id,
+      start: new Date(start),
+      end: new Date(end),
+    });
+
     updateEvent(
       { id: event.id, start: new Date(start), end: new Date(end) },
       {
@@ -158,12 +164,6 @@ export default function Calendar() {
         },
       }
     );
-
-    updateLocalEvent({
-      id: event.id,
-      start: new Date(start),
-      end: new Date(end),
-    });
 
     toast.success('약속 시간이 변경되었습니다.');
   };

--- a/src/app/(pages)/(nav)/calendar/page.tsx
+++ b/src/app/(pages)/(nav)/calendar/page.tsx
@@ -128,7 +128,15 @@ export default function Calendar() {
   };
 
   const moveEventsHandler = ({ event, start, end }: DragEventType) => {
-    updateEvent({ id: event.id, start: new Date(start), end: new Date(end) });
+    updateEvent(
+      { id: event.id, start: new Date(start), end: new Date(end) },
+      {
+        onError: () => {
+          toast.error('시간 변경에 실패했습니다.');
+          updateLocalEvent({ id: event.id, start: event.start, end: event.end }); // 롤백
+        },
+      }
+    );
 
     updateLocalEvent({
       id: event.id,
@@ -203,7 +211,7 @@ export default function Calendar() {
           <>
             <h2 className='mb-4 text-xl font-bold'>약속 추가</h2>
             <div className='m-5'>
-              <PlanForm initialValues={initialFormData ?? undefined} handleCancel={setShowPlanForm}/>
+              <PlanForm initialValues={initialFormData ?? undefined} handleCancel={setShowPlanForm} />
             </div>
           </>
         ) : isEditMode && editPlan ? (

--- a/src/app/(pages)/(nav)/calendar/page.tsx
+++ b/src/app/(pages)/(nav)/calendar/page.tsx
@@ -97,8 +97,12 @@ export default function Calendar() {
     );
   };
 
-  const handleEditClose = (updatedPlan: EditPlanType) => {
-    if (!updatedPlan) return; // 수정 취소한 경우
+  const handleEditClose = (updatedPlan: EditPlanType | null) => {
+    if (!updatedPlan) {
+      setIsEditMode(false);
+      setEditPlan(null);
+      return;
+    } // 수정 취소한 경우
 
     updateLocalEvent({
       id: updatedPlan.plan_id,
@@ -107,9 +111,6 @@ export default function Calendar() {
       end: new Date(updatedPlan.end_date),
       colors: updatedPlan.colors,
     });
-    // 수정 끝났으니, 모드 끄고 selectPlan을 수정한 걸로 새로 세팅
-    setIsEditMode(false);
-    setEditPlan(null);
 
     setSelectPlan([
       {

--- a/src/app/(pages)/(nav)/calendar/page.tsx
+++ b/src/app/(pages)/(nav)/calendar/page.tsx
@@ -88,10 +88,12 @@ export default function Calendar() {
             <div className='m-5'>
               <EditPlanForm
                 plan={editPlan}
-                onClose={() => {
+                onClose={(updatedPlan) => {
                   setIsEditMode(false);
                   setEditPlan(null);
-                  // setSelectPlan(null);
+                  if (updatedPlan) {
+                    setSelectPlan([updatedPlan]);
+                  }
                 }}
               />
             </div>

--- a/src/app/(pages)/(nav)/calendar/page.tsx
+++ b/src/app/(pages)/(nav)/calendar/page.tsx
@@ -91,7 +91,7 @@ export default function Calendar() {
                 onClose={() => {
                   setIsEditMode(false);
                   setEditPlan(null);
-                  setSelectPlan(null);
+                  // setSelectPlan(null);
                 }}
               />
             </div>

--- a/src/app/(pages)/(nav)/calendar/page.tsx
+++ b/src/app/(pages)/(nav)/calendar/page.tsx
@@ -14,6 +14,7 @@ import { usePlanFormStore } from '@/store/zustand/usePlanFormStore';
 import { planFormDefaultValues } from '@/lib/schemas/plansSchema';
 import { useGetHolidays } from '@/hooks/queries/useGetHolidays';
 import { useGetCalendarPlans } from '@/hooks/queries/useGetCalendarPlans';
+import { toast } from 'react-toastify';
 
 export default function Calendar() {
   const router = useRouter();
@@ -81,6 +82,24 @@ export default function Calendar() {
           : event
       )
     );
+    // 수정 끝났으니, 모드 끄고 selectPlan을 수정한 걸로 새로 세팅
+    setIsEditMode(false);
+    setEditPlan(null);
+
+    setSelectPlan([
+      {
+        plan_id: updatedPlan.plan_id,
+        user_id: updatedPlan.user_id,
+        contacts_id: updatedPlan.contacts_id,
+        title: updatedPlan.title,
+        detail: updatedPlan.detail,
+        start_date: updatedPlan.start_date,
+        end_date: updatedPlan.end_date,
+        colors: updatedPlan.colors,
+        priority: updatedPlan.priority,
+      },
+    ]);
+    toast.success('약속이 수정되었습니다.');
   };
 
   // 약속 + 공휴일

--- a/src/components/calendar/MainCalendar.tsx
+++ b/src/components/calendar/MainCalendar.tsx
@@ -4,24 +4,18 @@ import CustomToolbar from '@/components/calendar/CustomToolbar';
 import { useEffect, useState } from 'react';
 import type { CalendarEventType, PlansType } from '@/types/plans';
 import withDragAndDrop from 'react-big-calendar/lib/addons/dragAndDrop';
-import { useUpadateEventMutate } from '@/hooks/mutations/useUpadateEventMutate';
 import { CustomDateHeader } from '@/components/calendar/CustomDateHeader';
 import { holidayStyle } from '@/lib/utils/calendarStyle';
 import CalendarPopOver from '@/components/calendar/popOver/CalendarPopOver';
 import { useGetSelectPlan } from '@/hooks/queries/useGetSelectPlan';
-
-// 드래그 이벤트 타입
-interface Props {
-  event: CalendarEventType;
-  start: string | Date;
-  end: string | Date;
-}
+import { DragEventType } from '@/app/(pages)/(nav)/calendar/page';
 
 interface MainCalendarProps {
   events: CalendarEventType[];
   moment: Date;
   setMoment: (date: Date) => void;
   setSelectPlan: React.Dispatch<React.SetStateAction<PlansType[] | null>>;
+  onEventDrop: (data: DragEventType) => void;
   CustomToolbarProps: {
     onShowUpcomingPlans: () => void;
     onAddPlan: () => void;
@@ -36,21 +30,21 @@ const localizer = dateFnsLocalizer({
   locales: {},
 });
 
-const MainCalendar = ({ setSelectPlan, CustomToolbarProps, events, moment, setMoment }: MainCalendarProps) => {
+const MainCalendar = ({
+  setSelectPlan,
+  CustomToolbarProps,
+  events,
+  moment,
+  setMoment,
+  onEventDrop,
+}: MainCalendarProps) => {
   const [selectedDate, setSelectedDate] = useState<Date | null>(null); //선택한 셀 날짜
   const [isPopOverOpen, setIsPopOverOpen] = useState(false); //팝오버 오픈 여부
   const [selectedPlanId, setSelectedPlanId] = useState<string | null>(null);
 
   const { data: selectedPlanData, refetch } = useGetSelectPlan(selectedPlanId ?? '');
-  const { mutate: updateEvent } = useUpadateEventMutate();
 
   const DnDCalendar = withDragAndDrop<CalendarEventType>(Calendar); //DnD 사용 캘린더
-
-  // 드래그 종료 함수(mutate 실행 핸들러)
-  const moveEventsHandler = ({ event, start, end }: Props) => {
-    // mutation의 Date 타입과 일치
-    updateEvent({ id: event.id, start: new Date(start), end: new Date(end) });
-  };
 
   const selectPlanHandler = async (event: CalendarEventType) => {
     // selectedPlanId가 바뀌는 순간 새로운 useQuery가 실행되도록
@@ -88,7 +82,7 @@ const MainCalendar = ({ setSelectPlan, CustomToolbarProps, events, moment, setMo
         }}
         startAccessor='start'
         endAccessor='end'
-        onEventDrop={moveEventsHandler} // 드래그 종료
+        onEventDrop={onEventDrop} // 드래그 종료
         defaultView='month'
         views={['month']}
         components={{

--- a/src/components/contactDetail/editPlanForm/EditPlanForm.tsx
+++ b/src/components/contactDetail/editPlanForm/EditPlanForm.tsx
@@ -18,7 +18,7 @@ import { toast } from 'react-toastify';
 
 interface Props {
   plan: EditPlanType;
-  onClose: (updatedPlan: EditPlanType) => void;
+  onClose: (updatedPlan: EditPlanType | null) => void;
 }
 
 const convertToFormValues = (plan: EditPlanType): PlanFormType => ({
@@ -54,7 +54,7 @@ const EditPlanForm = ({ plan, onClose }: Props) => {
   });
 
   const handleCancel = () => {
-    onClose(plan);
+    onClose(null);
   };
 
   const { mutate: updatePlan } = useMutateUpdatePlan();

--- a/src/components/contactDetail/editPlanForm/EditPlanForm.tsx
+++ b/src/components/contactDetail/editPlanForm/EditPlanForm.tsx
@@ -18,7 +18,7 @@ import { toast } from 'react-toastify';
 
 interface Props {
   plan: EditPlanType;
-  onClose: () => void;
+  onClose: (updatedPlan: EditPlanType) => void;
 }
 
 const convertToFormValues = (plan: EditPlanType): PlanFormType => ({
@@ -42,7 +42,7 @@ const convertToFormValues = (plan: EditPlanType): PlanFormType => ({
   colors: plan.colors ?? '',
 });
 
-const EditPlanForm: React.FC<Props> = ({ plan, onClose }) => {
+const EditPlanForm = ({ plan, onClose }: Props) => {
   const user = useAuthStore((state) => state.user);
   const [inputValue, setInputValue] = useState(plan.location?.place_name || '');
   const [selectedColor, setSelectedColor] = useState(plan.colors || '#2F80ED');
@@ -53,18 +53,32 @@ const EditPlanForm: React.FC<Props> = ({ plan, onClose }) => {
     defaultValues: convertToFormValues(plan),
   });
 
+  const handleCancel = () => {
+    onClose(plan);
+  };
+
   const { mutate: updatePlan } = useMutateUpdatePlan();
 
   const editPlanHandler = (data: PlanFormType) => {
     const formData = mappingFormData(data);
     const updatedForm = { ...formData, colors: selectedColor };
 
+    const { start_date, end_date, ...restFormData } = updatedForm;
+
     updatePlan(
-      { planId: plan.plan_id, updatedData: { ...updatedForm, user_id: plan.user_id } },
+      { planId: plan.plan_id, updatedData: { ...restFormData, user_id: plan.user_id } },
       {
         onSuccess: () => {
-          toast.success('약속이 수정되었습니다.');
-          onClose();
+          const updatedPlan = {
+            ...plan,
+            ...restFormData,
+            detail: restFormData.detail ?? '',
+            priority: restFormData.priority ?? '',
+            start_date,
+            end_date,
+          };
+
+          onClose(updatedPlan);
         },
         onError: () => toast.error('약속 수정에 실패했습니다.'),
       }
@@ -82,7 +96,7 @@ const EditPlanForm: React.FC<Props> = ({ plan, onClose }) => {
         <PriorityField />
         <DetailField />
         <div className='flex w-full flex-row items-center justify-center gap-4'>
-          <Button type='button' variant='outline' onClick={onClose} className='flex-1'>
+          <Button type='button' variant='outline' onClick={handleCancel} className='flex-1'>
             취소
           </Button>
           <Button type='submit' disabled={form.formState.isSubmitting} className='flex-1'>

--- a/src/types/plans.ts
+++ b/src/types/plans.ts
@@ -91,7 +91,7 @@ export interface EditPlanType {
   start_date: string;
   end_date: string;
   location?: Partial<KakaoPlaceType> | null;
-  colors?: string;
+  colors: string;
 }
 
 export interface SelectPlanType extends PlansType {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #118 

<br>

## 📝 작업 내용

> 캘린더 페이지에서 약속 수정 후 사이드 닫힘 및 약속 바 클릭 오류를 수정했습니다.

<br>

## 🖼 스크린샷
![PR](https://github.com/user-attachments/assets/057340f1-cc67-4458-828b-4da2c146e8fa)

<br>

## 💬리뷰 요구사항

- 캘린더 페이지 전체에서 약속 데이터를 관리해야 하기 때문에(캘린더 컴포넌트 외에도 다른 컴포넌트들이 연결됨)
데이터 페칭을 캘린더 페이지로 옮겼습니다.
- 캘린더 페이지와 약속 수정 로직이 연동되어야 하기 때문에 EditPlanForm.tsx 파일을 수정하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 캘린더 페이지에서 일정 및 공휴일을 비동기적으로 불러오고, 로컬 상태에서 일정을 편집할 수 있습니다.
  - 드래그 앤 드롭으로 일정 시간을 변경할 수 있으며, 성공 및 오류 알림이 표시됩니다.
  - 일정 상세 정보 조회 및 편집 기능이 향상되었습니다.

- **버그 수정**
  - 일정 편집 시 로컬 상태와 UI가 정확히 동기화됩니다.
  - 데이터 로딩 및 오류 상태에 대한 안내 메시지가 추가되었습니다.

- **리팩터링**
  - 캘린더 UI 컴포넌트가 데이터 관리 없이 표시 역할만 수행하도록 구조가 개선되었습니다.

- **문서화**
  - 일정 데이터 타입 및 필수 속성 정의가 명확해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->