### PR TITLE
Bugfix/#115 duplicate signup alert

### DIFF
--- a/src/app/(pages)/signIn/page.tsx
+++ b/src/app/(pages)/signIn/page.tsx
@@ -18,6 +18,7 @@ const SignIn = () => {
       router.replace(PEOPLE);
     }
   }, [isSignin, router]);
+
   return (
     <div className='flex h-[100vh] w-[100vw] items-center justify-center overflow-hidden overflow-y-auto'>
       <section className='flex w-1/2 flex-col items-center justify-center'>

--- a/src/app/(pages)/signIn/page.tsx
+++ b/src/app/(pages)/signIn/page.tsx
@@ -1,12 +1,23 @@
 'use client';
 
-import { SIGNUP } from '@/constants/paths';
+import { PEOPLE, SIGNUP } from '@/constants/paths';
 import Link from 'next/link';
 import Image from 'next/image';
 import SigninForm from '@/components/signin/SigninForm';
 import SigninSocial from '@/components/signin/SigninSocial';
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+import { useAuthStore } from '@/store/zustand/store';
 
 const SignIn = () => {
+  const router = useRouter();
+  const isSignin = useAuthStore((state) => state.isSignIn);
+
+  useEffect(() => {
+    if (isSignin) {
+      router.replace(PEOPLE);
+    }
+  }, [isSignin, router]);
   return (
     <div className='flex h-[100vh] w-[100vw] items-center justify-center overflow-hidden overflow-y-auto'>
       <section className='flex w-1/2 flex-col items-center justify-center'>

--- a/src/app/api/supabase/service.ts
+++ b/src/app/api/supabase/service.ts
@@ -75,7 +75,7 @@ export const signInUser = async (value: { email: string; password: string }) => 
 };
 
 // 로그아웃
-export const mutateSignOut = async () => {
+export const SignOutUser = async () => {
   const { error } = await supabase.auth.signOut();
   if (error) {
     console.error('로그아웃에 실패했습니다. 다시 시도해주세요.', error);
@@ -207,6 +207,7 @@ export const mutateUpdateContactPin = async (contactId: string, isPinned: boolea
   }
 };
 
+//구글 로그인
 export const signInWithGoogle = async () => {
   const { error } = await supabase.auth.signInWithOAuth({
     provider: 'google',
@@ -222,6 +223,8 @@ export const signInWithGoogle = async () => {
 
   return error;
 };
+
+//카카오 로그인
 export const signInWithKakao = async () => {
   const { error } = await supabase.auth.signInWithOAuth({
     provider: 'kakao',

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -3,6 +3,8 @@
 import { useEffect } from 'react';
 import { supabase } from '@/app/api/supabase/client';
 import { useRouter } from 'next/navigation';
+import { toast } from 'react-toastify';
+import { PEOPLE, SIGNIN } from '@/constants/paths';
 
 // 컴포넌트 마운트 시 현재 로그인 세션 확인
 // 세션이 있으면 '/people'로
@@ -11,11 +13,15 @@ const AuthCallbackPage = () => {
   const router = useRouter();
 
   useEffect(() => {
+    toast.success(`로그인에 성공했습니다. '내사람'으로 이동합니다.`);
+  }, []);
+
+  useEffect(() => {
     supabase.auth.getSession().then(({ data: { session } }) => {
       if (session) {
-        router.replace('/people');
+        router.replace(PEOPLE);
       } else {
-        router.replace('/signin');
+        router.replace(SIGNIN);
       }
     });
   }, [router]);

--- a/src/hooks/useSignin.ts
+++ b/src/hooks/useSignin.ts
@@ -11,6 +11,7 @@ export const useSignin = () => {
   const SignInHandler = async (value: SignInFormType) => {
     const { data, error } = await signInUser(value);
     if (data.session) {
+      toast.success(`로그인에 성공했습니다. '내사람'으로 이동합니다.`);
       router.replace(PEOPLE);
     } else if (error) {
       toast.warning('아이디 또는 비밀번호를 확인해주세요.');

--- a/src/hooks/useSignin.ts
+++ b/src/hooks/useSignin.ts
@@ -11,7 +11,7 @@ export const useSignin = () => {
   const SignInHandler = async (value: SignInFormType) => {
     const { data, error } = await signInUser(value);
     if (data.session) {
-      router.push(PEOPLE);
+      router.replace(PEOPLE);
     } else if (error) {
       toast.warning('아이디 또는 비밀번호를 확인해주세요.');
     }

--- a/src/hooks/useSignup.ts
+++ b/src/hooks/useSignup.ts
@@ -25,7 +25,7 @@ export const useSignup = () => {
       localStorage.setItem('alreadySignIn', 'true');
       toast.success(`회원가입이 완료되었습니다.`);
       setUser(data.session.user);
-      router.push(PEOPLE);
+      router.replace(PEOPLE);
     } else if (error) {
       toast.warning('입력한 정보를 다시 한 번 확인해주세요.');
     }

--- a/src/hooks/useSignup.ts
+++ b/src/hooks/useSignup.ts
@@ -23,7 +23,7 @@ export const useSignup = () => {
     const { data, error } = await signUpUser(value);
     if (data.session) {
       localStorage.setItem('alreadySignIn', 'true');
-      toast.success(`회원가입이 완료되었습니다. 자동으로 로그인되어 '내 사람' 페이지로 이동합니다.`);
+      toast.success(`회원가입이 완료되었습니다.`);
       setUser(data.session.user);
       router.push(PEOPLE);
     } else if (error) {

--- a/src/hooks/useSignup.ts
+++ b/src/hooks/useSignup.ts
@@ -1,7 +1,6 @@
 import { signUpUser } from '@/app/api/supabase/service';
 import { SignUpFormType } from '@/components/signup/SignupForm';
 import { PEOPLE } from '@/constants/paths';
-import { useAuthStore } from '@/store/zustand/store';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { toast } from 'react-toastify';
@@ -11,7 +10,6 @@ export const useSignup = () => {
   const [isEmailChecked, setIsEmailChecked] = useState<boolean>(false);
 
   const router = useRouter();
-  const setUser = useAuthStore((state) => state.setUser);
 
   //회원가입 기능 핸들러
   const SignUpHandler = async (value: SignUpFormType) => {
@@ -22,9 +20,7 @@ export const useSignup = () => {
 
     const { data, error } = await signUpUser(value);
     if (data.session) {
-      localStorage.setItem('alreadySignIn', 'true');
       toast.success(`회원가입이 완료되었습니다.`);
-      setUser(data.session.user);
       router.replace(PEOPLE);
     } else if (error) {
       toast.warning('입력한 정보를 다시 한 번 확인해주세요.');

--- a/src/hooks/useSignup.ts
+++ b/src/hooks/useSignup.ts
@@ -20,7 +20,7 @@ export const useSignup = () => {
 
     const { data, error } = await signUpUser(value);
     if (data.session) {
-      toast.success(`회원가입이 완료되었습니다.`);
+      toast.success(`회원가입을 성공했습니다.'내사람'으로 이동합니다.`);
       router.replace(PEOPLE);
     } else if (error) {
       toast.warning('입력한 정보를 다시 한 번 확인해주세요.');

--- a/src/store/zustand/store.ts
+++ b/src/store/zustand/store.ts
@@ -41,10 +41,9 @@ export const AuthStateChangeHandler = () => {
     if ((event === 'INITIAL_SESSION' || event === 'SIGNED_IN') && session) {
       setUser(session.user);
 
-      // 토스트는 실제 로그인 액션 때만 띄우기
       if (event === 'SIGNED_IN' && !alreadySignIn) {
         localStorage.setItem('alreadySignIn', 'true');
-        toast.success(`로그인되었습니다. '내 사람'페이지로 이동합니다.`);
+        toast.success(`로그인되었습니다. '내 사람'으로 이동합니다.`);
       }
     } else if (event === 'SIGNED_OUT') {
       localStorage.removeItem('alreadySignIn');

--- a/src/store/zustand/store.ts
+++ b/src/store/zustand/store.ts
@@ -1,5 +1,5 @@
 import { supabase } from '@/app/api/supabase/client';
-import { mutateSignOut } from '@/app/api/supabase/service';
+import { SignOutUser } from '@/app/api/supabase/service';
 import { User } from '@supabase/supabase-js';
 import { toast } from 'react-toastify';
 import { create } from 'zustand';
@@ -21,9 +21,8 @@ export const useAuthStore = create<AuthStateType>()(
       ...initialState,
       setUser: (user) => set({ user, isSignIn: true }),
       signOut: async () => {
-        await mutateSignOut();
+        await SignOutUser();
         set(initialState);
-        toast.success(`로그아웃되었습니다.`);
       },
     }),
     {
@@ -45,10 +44,11 @@ export const AuthStateChangeHandler = () => {
       // 토스트는 실제 로그인 액션 때만 띄우기
       if (event === 'SIGNED_IN' && !alreadySignIn) {
         localStorage.setItem('alreadySignIn', 'true');
-        toast.success(`로그인되었습니다. '내 사람' 페이지로 이동합니다.`);
+        toast.success(`로그인되었습니다. '내 사람'페이지로 이동합니다.`);
       }
     } else if (event === 'SIGNED_OUT') {
       localStorage.removeItem('alreadySignIn');
+      toast.success(`로그아웃되었습니다.`);
     }
   });
 

--- a/src/store/zustand/store.ts
+++ b/src/store/zustand/store.ts
@@ -41,9 +41,8 @@ export const AuthStateChangeHandler = () => {
     if ((event === 'INITIAL_SESSION' || event === 'SIGNED_IN') && session) {
       setUser(session.user);
 
-      if (event === 'SIGNED_IN' && !alreadySignIn) {
+      if (!alreadySignIn) {
         localStorage.setItem('alreadySignIn', 'true');
-        toast.success(`로그인되었습니다. '내 사람'으로 이동합니다.`);
       }
     } else if (event === 'SIGNED_OUT') {
       localStorage.removeItem('alreadySignIn');


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #115 

<br>

## 📝 작업 내용

>로그인/회원가입 성공 toast가 중복으로 나오는 현상 해결
> onAuthStateChange에 있던 로그인 성공 toast를 지우고, 로그인/회원가입/소셜로그인 각각의 로직에 toast 작성

<br>

## 🖼 스크린샷
![스크린샷 2025-04-21 203954](https://github.com/user-attachments/assets/880f645b-fa7e-444c-9850-0c3f4836d6f5)
![스크린샷 2025-04-21 192852](https://github.com/user-attachments/assets/ce3dbe42-317a-400d-afa7-6aa478f2846f)



