### PR TITLE
Bugfix/#123 calendar errors

### DIFF
--- a/src/app/(pages)/(nav)/calendar/page.tsx
+++ b/src/app/(pages)/(nav)/calendar/page.tsx
@@ -87,7 +87,13 @@ export default function Calendar() {
       // 클릭한 약속 바
       const clickPlan = selectedPlanData.data[0];
 
-      setSelectPlan([{ ...clickPlan, contacts: clickPlan.contacts[0] }]);
+      const formattedPlan = {
+        ...clickPlan,
+        contacts: Array.isArray(clickPlan.contacts)
+          ? (clickPlan.contacts[0] ?? { name: '' }) // 배열이면 첫 번째 꺼내고
+          : (clickPlan.contacts ?? { name: '' }), // 객체거나 null이면 그대로
+      };
+      setSelectPlan([formattedPlan]);
       setShowUpcoming(false);
       setShowPlanForm(false);
       setIsEditMode(false);
@@ -238,7 +244,7 @@ export default function Calendar() {
         {showPlanForm ? (
           <>
             <h2 className='mb-4 text-xl font-bold'>약속 추가</h2>
-            <div className='m-5'>
+            <div className='m-6'>
               <PlanForm initialValues={initialFormData ?? undefined} handleCancel={setShowPlanForm} />
             </div>
           </>
@@ -252,7 +258,7 @@ export default function Calendar() {
         ) : selectPlan ? (
           <>
             <h2 className='mb-4 text-xl font-bold'>약속 상세</h2>
-            <div className='p-12'>
+            <div className='p-11'>
               <SelectPlan
                 plans={selectPlan}
                 onEdit={() => {

--- a/src/app/(pages)/(nav)/calendar/page.tsx
+++ b/src/app/(pages)/(nav)/calendar/page.tsx
@@ -239,7 +239,7 @@ export default function Calendar() {
         ) : isEditMode && editPlan ? (
           <>
             <h2 className='mb-4 text-xl font-bold'>약속 수정</h2>
-            <div className='m-5'>
+            <div className='m-7'>
               <EditPlanForm plan={editPlan} onClose={handleEditClose} />
             </div>
           </>

--- a/src/app/(pages)/(nav)/calendar/page.tsx
+++ b/src/app/(pages)/(nav)/calendar/page.tsx
@@ -251,7 +251,14 @@ export default function Calendar() {
           <>
             <h2 className='mb-4 text-xl font-bold'>약속 추가</h2>
             <div className='m-6'>
-              <PlanForm initialValues={initialFormData ?? undefined} handleCancel={setShowPlanForm} />
+              <PlanForm
+                initialValues={initialFormData ?? undefined}
+                handleCancel={(show) => {
+                  setShowPlanForm(show);
+                  setShowUpcoming(true);
+                }}
+                mode='calendar'
+              />
             </div>
           </>
         ) : isEditMode && editPlan ? (

--- a/src/app/(pages)/(nav)/calendar/page.tsx
+++ b/src/app/(pages)/(nav)/calendar/page.tsx
@@ -257,7 +257,6 @@ export default function Calendar() {
                   setShowPlanForm(show);
                   setShowUpcoming(true);
                 }}
-                mode='calendar'
               />
             </div>
           </>

--- a/src/app/(pages)/(nav)/calendar/page.tsx
+++ b/src/app/(pages)/(nav)/calendar/page.tsx
@@ -124,7 +124,7 @@ export default function Calendar() {
     );
   };
 
-  const handleEditClose = (updatedPlan: EditPlanType | null) => {
+  const handleEditClose = async (updatedPlan: EditPlanType | null) => {
     if (!updatedPlan) {
       setIsEditMode(false);
       setEditPlan(null);
@@ -152,6 +152,12 @@ export default function Calendar() {
         priority: updatedPlan.priority,
       },
     ]);
+    setIsEditMode(false); // 수정 모드 종료
+    setEditPlan(null);
+
+    // 최신 데이터를 다시 가져옴
+    await refetchSelectedPlan();
+
     toast.success('약속이 수정되었습니다.');
   };
 

--- a/src/app/(pages)/(nav)/calendar/page.tsx
+++ b/src/app/(pages)/(nav)/calendar/page.tsx
@@ -17,6 +17,7 @@ import { useGetCalendarPlans } from '@/hooks/queries/useGetCalendarPlans';
 import { toast } from 'react-toastify';
 import { useUpadateEventMutate } from '@/hooks/mutations/useUpadateEventMutate';
 import { useGetSelectPlan } from '@/hooks/queries/useGetSelectPlan';
+import { format } from 'date-fns';
 
 interface UpdatedEventType {
   id: string;
@@ -149,14 +150,19 @@ export default function Calendar() {
   };
 
   const moveEventsHandler = ({ event, start, end }: DragEventType) => {
+    // 캘린더에서는 Date 객체를 유지
     updateLocalEvent({
       id: event.id,
       start: new Date(start),
       end: new Date(end),
     });
 
+    // DB에는 string 포맷으로 변환해서 저장
+    const formattedStart = format(start, 'yyyy-MM-dd HH:mm:ss');
+    const formattedEnd = format(end, 'yyyy-MM-dd HH:mm:ss');
+
     updateEvent(
-      { id: event.id, start: new Date(start), end: new Date(end) },
+      { id: event.id, start: formattedStart, end: formattedEnd },
       {
         onError: () => {
           toast.error('시간 변경에 실패했습니다.');

--- a/src/app/(pages)/(nav)/calendar/page.tsx
+++ b/src/app/(pages)/(nav)/calendar/page.tsx
@@ -278,6 +278,10 @@ export default function Calendar() {
                   setIsEditMode(true);
                   setEditPlan(selectPlan[0]);
                 }}
+                onDeleteSuccess={() => {
+                  setSelectPlan(null); // selectPlan 비우고
+                  setShowUpcoming(true); // UpcomingPlans 보이게
+                }}
               />
             </div>
           </>

--- a/src/app/api/supabase/service.ts
+++ b/src/app/api/supabase/service.ts
@@ -121,12 +121,12 @@ export const getMonthlyPlans = async (user: User, year: number, month: number): 
 };
 
 // plans 데이터 업데이트 (캘린더 DnD)
-export const updateEventInSupabase = async (id: string, { start, end }: { start: Date; end: Date }) => {
+export const updateEventInSupabase = async (id: string, { start, end }: { start: string; end: string }) => {
   const { error } = await supabase
     .from(PLANS)
     .update({
-      start_date: start.toISOString(),
-      end_date: end.toISOString(),
+      start_date: start,
+      end_date: end,
     })
     .eq('plan_id', id);
 

--- a/src/components/calendar/AddPlanButton.tsx
+++ b/src/components/calendar/AddPlanButton.tsx
@@ -5,7 +5,7 @@ const AddPlanButton = ({ onClick }: { onClick: () => void }) => {
     <div>
       <button
         onClick={onClick}
-        className='items-center justify-center rounded-md border-[1px] border-primary-500 px-[20px] py-[12px] text-[14px] font-bold text-[#0066FF]'
+        className='items-center justify-center rounded-md border-[1px] border-primary-500 px-5 py-3 text-[14px] font-bold text-[#0066FF]'
       >
         약속 추가
       </button>

--- a/src/components/calendar/CustomToolbar.tsx
+++ b/src/components/calendar/CustomToolbar.tsx
@@ -17,8 +17,8 @@ const CustomToolbar = ({ date, onNavigate, onShowUpcomingPlans, onAddPlan }: Cus
   return (
     <div className='mt-[18px] flex'>
       <MoveMonthButton onNavigate={onNavigate} />
-      <span className='ml-[24px] text-[28px] font-bold'>{customLabel}</span>
-      <section className='mb-[12.5px] ml-auto mr-[9px] flex'>
+      <span className='ml-6 text-[28px] font-bold'>{customLabel}</span>
+      <section className='mb-[12.5px] ml-auto mr-2 flex'>
         <UpcomingPlanButton onClick={onShowUpcomingPlans} />
         <AddPlanButton onClick={onAddPlan} />
       </section>

--- a/src/components/calendar/SelectPlan.tsx
+++ b/src/components/calendar/SelectPlan.tsx
@@ -8,18 +8,20 @@ import { toast } from 'react-toastify';
 interface SelectPlanProps {
   plans: SelectPlanType[];
   onEdit: () => void;
+  onDeleteSuccess: () => void;
 }
 
-const SelectPlan = ({ plans, onEdit }: SelectPlanProps) => {
-  const deleteMutation = useMutateDeleteSelectPlan();
+const SelectPlan = ({ plans, onEdit, onDeleteSuccess }: SelectPlanProps) => {
+  const { mutate } = useMutateDeleteSelectPlan();
 
   const deletePlanHandler = (planId: string) => {
     ConfirmToast({
       message: '정말로 해당 약속을 삭제하시겠습니까?',
       onConfirm: () => {
-        deleteMutation.mutate(planId, {
+        mutate(planId, {
           onSuccess: () => {
             toast.success('성공적으로 삭제되었습니다.');
+            onDeleteSuccess();
           },
         });
       },

--- a/src/components/calendar/SelectPlan.tsx
+++ b/src/components/calendar/SelectPlan.tsx
@@ -71,9 +71,9 @@ const SelectPlan = ({ plans, onEdit }: SelectPlanProps) => {
               <section className='flex items-center gap-8'>
                 <div className='relative flex w-14 flex-shrink-0 flex-grow-0 flex-col items-center justify-center gap-1'>
                   <User size={24} className='h-6 w-6 flex-shrink-0 flex-grow-0' />{' '}
-                  <p className='text-center text-sm'>이름</p>
+                  <p className='text-center text-sm'>내 사람</p>
                 </div>
-                <p>{plan.contacts?.name}</p>
+                <p>{plan.contacts?.name ?? '없음'}</p>
               </section>
               <section className='flex items-center gap-8'>
                 <div className='relative flex w-14 flex-shrink-0 flex-grow-0 flex-col items-center justify-center gap-1'>

--- a/src/components/calendar/UpcomingPlanButton.tsx
+++ b/src/components/calendar/UpcomingPlanButton.tsx
@@ -18,7 +18,7 @@ const UpcomingPlanButton = ({ onClick }: { onClick: () => void }) => {
 
   return (
     <div>
-      <button onClick={onClick} className='mr-[24px] rounded-md border-[1px] px-[20px] py-[12px] text-[14px] font-bold'>
+      <button onClick={onClick} className='mr-6 rounded-md border-[1px] px-5 py-3 text-[14px] font-bold'>
         다가오는 약속
         <span className='m-1 rounded-full bg-black px-1 text-white'>
           {upcomingCount !== null ? upcomingCount : '-'}

--- a/src/components/contactDetail/ContactPlans.tsx
+++ b/src/components/contactDetail/ContactPlans.tsx
@@ -75,7 +75,7 @@ const ContactPlans = ({ plans }: Props) => {
 
       {/* 사이드 시트 - 약속 추가 */}
       <SideSheet isOpen={isAddPlanOpen} onClose={() => setIsAddPlanOpen(false)} title='약속 추가'>
-        <PlanForm handleCancel={setIsAddPlanOpen} mode='contact' />
+        <PlanForm handleCancel={setIsAddPlanOpen} />
       </SideSheet>
 
       {/* 사이드 시트 - 약속 수정 */}

--- a/src/components/contactDetail/ContactPlans.tsx
+++ b/src/components/contactDetail/ContactPlans.tsx
@@ -75,7 +75,7 @@ const ContactPlans = ({ plans }: Props) => {
 
       {/* 사이드 시트 - 약속 추가 */}
       <SideSheet isOpen={isAddPlanOpen} onClose={() => setIsAddPlanOpen(false)} title='약속 추가'>
-        <PlanForm handleCancel={setIsAddPlanOpen}/>
+        <PlanForm handleCancel={setIsAddPlanOpen} mode='contact' />
       </SideSheet>
 
       {/* 사이드 시트 - 약속 수정 */}

--- a/src/components/contactDetail/editPlanForm/EditPlanForm.tsx
+++ b/src/components/contactDetail/editPlanForm/EditPlanForm.tsx
@@ -66,7 +66,7 @@ const EditPlanForm = ({ plan, onClose }: Props) => {
     const { start_date, end_date, ...restFormData } = updatedForm;
 
     updatePlan(
-      { planId: plan.plan_id, updatedData: { ...restFormData, user_id: plan.user_id } },
+      { planId: plan.plan_id, updatedData: { ...restFormData, user_id: plan.user_id, start_date, end_date } },
       {
         onSuccess: () => {
           const updatedPlan = {

--- a/src/components/plans/PlanForm.tsx
+++ b/src/components/plans/PlanForm.tsx
@@ -18,16 +18,12 @@ import ColorOptions from '@/components/calendar/popOver/ColorOptions';
 import { useAuthStore } from '@/store/zustand/store';
 import { usePlanColorStore } from '@/store/zustand/usePlanFormStore';
 
-type PlanFormMode = 'calendar' | 'contact'; //문자 자체를 타입으로 둠
-
 const PlanForm = ({
   initialValues,
   handleCancel,
-  mode,
 }: {
   initialValues?: PlanFormType;
   handleCancel: (show: boolean) => void;
-  mode?: PlanFormMode;
 }) => {
   const [inputValue, setInputValue] = useState('');
   const { selectedColor, setSelectedColor } = usePlanColorStore(); // 선택 색상
@@ -72,11 +68,7 @@ const PlanForm = ({
   };
 
   const cancelBtnHandler = () => {
-    if (mode === 'calendar') {
-      handleCancel(false); // 캘린더: UpcomingPlans 보여줌
-    } else {
-      handleCancel(false); // 약속 탭: 닫기
-    }
+    handleCancel(false);
   };
 
   return (

--- a/src/components/plans/PlanForm.tsx
+++ b/src/components/plans/PlanForm.tsx
@@ -18,12 +18,16 @@ import ColorOptions from '@/components/calendar/popOver/ColorOptions';
 import { useAuthStore } from '@/store/zustand/store';
 import { usePlanColorStore } from '@/store/zustand/usePlanFormStore';
 
+type PlanFormMode = 'calendar' | 'contact'; //문자 자체를 타입으로 둠
+
 const PlanForm = ({
   initialValues,
   handleCancel,
+  mode,
 }: {
   initialValues?: PlanFormType;
   handleCancel: (show: boolean) => void;
+  mode?: PlanFormMode;
 }) => {
   const [inputValue, setInputValue] = useState('');
   const { selectedColor, setSelectedColor } = usePlanColorStore(); // 선택 색상
@@ -68,7 +72,11 @@ const PlanForm = ({
   };
 
   const cancelBtnHandler = () => {
-    handleCancel(false);
+    if (mode === 'calendar') {
+      handleCancel(false); // 캘린더: UpcomingPlans 보여줌
+    } else {
+      handleCancel(false); // 약속 탭: 닫기
+    }
   };
 
   return (

--- a/src/hooks/mutations/useMutateInsertNewPlan.ts
+++ b/src/hooks/mutations/useMutateInsertNewPlan.ts
@@ -11,6 +11,7 @@ const useMutateInsertNewPlan = () => {
       queryClient.invalidateQueries({
         queryKey: [QUERY_KEY.CONTACT_WITH_PLANS],
       });
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEY.PLANS] });
     },
   });
 };

--- a/src/hooks/mutations/useUpadateEventMutate.ts
+++ b/src/hooks/mutations/useUpadateEventMutate.ts
@@ -4,8 +4,8 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 interface Props {
   id: string;
-  start: Date;
-  end: Date;
+  start: string;
+  end: string;
 }
 
 // 약속 업데이트 커스텀 훅

--- a/src/types/plans.ts
+++ b/src/types/plans.ts
@@ -97,5 +97,5 @@ export interface EditPlanType {
 export interface SelectPlanType extends PlansType {
   contacts?: {
     name: string;
-  };
+  } | null;
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #123 

<br>

## 📝 작업 내용

> 캘린더 페이지에서 발생하는 오류들을 개선했습니다.

1. string으로 저장되어야 하는 start_date와 end_date가 드래그 앤 드롭 시, 타임존 형태로 변형됨
2. 또한 캘린더 페이지에서 약속 수정을 하면, 날짜만 반영이 안 됨
3. 약속 수정에서 설정한 '내 사람'이 잘 타나나지 않음
4. 약속 수정 폼에서 약속 내용 수정
5. 약속 추가 폼 내부의 '취소' 버튼을 클릭하면 해당 컴포넌트가 아예 사라짐
6. 약속 삭제 후에도 약속 상세가 나타남

👇🏻

1. 추가, 수정, DnD 시 모두 string으로 DB에 저장되며 캘린더에 그려질 때만 Date 객체로 타입 변환
2. 캘린더 페이지 내에서 약속 수정 시 정상적으로 반영됨
3. 설정한 내 사람이 잘 나타남
4. 약속 수정 직후 수정된 내용을 반영한 약속 상세 보여주기
5. '취소'버튼 클릭 시 다가오는 약속 보여주기
6. 약속 삭제 후 사이드에 다가오는 일정 보여주기

<br>

## 🖼 스크린샷

<br>

## 💬리뷰 요구사항
> 코드 수정이 많지 않고 오류 개선 사항을 한 번에 반영하기 위해 한 PR에 올렸습니다.
작동 영상은 추후에 올리겠습니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
	- 연락처 정보가 배열 또는 객체일 때 올바르게 처리되어, 연락처 이름이 없을 경우 "없음"으로 표시됩니다.
	- 일정 편집 시 시작 및 종료 시간이 올바른 문자열 형식으로 서버에 반영됩니다.
- **UI/스타일**
	- 여러 버튼과 도구 모음의 여백 및 패딩이 Tailwind CSS 단위로 일관성 있게 조정되었습니다.
- **기능 개선**
	- 일정 삭제 후 선택된 일정이 초기화되고, 곧 있을 일정이 표시됩니다.
	- 일정 추가, 수정, 삭제 시 데이터가 즉시 동기화되어 최신 정보가 반영됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->