### PR TITLE
Style/#110 people detail

### DIFF
--- a/src/components/contactDetail/ContactProfile.tsx
+++ b/src/components/contactDetail/ContactProfile.tsx
@@ -83,9 +83,9 @@ const ContactProfile = ({ contact, plans }: Props) => {
       <div className='border-t border-gray-200' />
 
       {/* 연락처 + 다가오는 약속 */}
-      <div className='flex flex-wrap gap-8'>
+      <div className='flex flex-col gap-8 md:flex-row'>
         {/* 연락처 정보 */}
-        <div className='flex-1 space-y-4'>
+        <div className='w-full md:w-1/2'>
           <h2 className='text-xl font-bold text-gray-800 mb-4'>연락처</h2>
           <div className='space-y-12 text-sm text-gray-700'>
             <p>
@@ -109,9 +109,9 @@ const ContactProfile = ({ contact, plans }: Props) => {
 
         {/* 다가오는 약속 */}
         {plans.length > 0 && (
-          <div className='flex-1'>
+          <div className='w-full md:w-1/2'>
             <h2 className='text-xl font-bold text-gray-800 mb-4'>다가오는 약속</h2>
-            <div className='grid grid-cols-1 gap-4 sm:grid-cols-2'>
+            <div className='grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-2 lg:grid-cols-2'>
               {plans.map((plan) => (
                 <ContactPlansCard
                   key={plan.plan_id}

--- a/src/components/contactDetail/ContactProfile.tsx
+++ b/src/components/contactDetail/ContactProfile.tsx
@@ -1,6 +1,5 @@
 import { ContactDetailType, PlanDetailType } from '@/types/contacts';
 import Image from 'next/image';
-import { Plus } from 'lucide-react';
 import { useState } from 'react';
 import SideSheet from '@/components/contacts/SideSheet';
 import EditContactForm from '@/components/contactDetail/editContactForm/EditContactForm';
@@ -9,6 +8,7 @@ import { useMutateDeleteContact } from '@/hooks/mutations/useMutateDeleteContact
 import { toast } from 'react-toastify';
 import ContactPlansCard from '@/components/contactDetail/ContactPlansCard';
 import { ConfirmToast } from '@/components/toast/ConfirmToast';
+import { PencilSimple, Trash } from '@phosphor-icons/react';
 
 interface Props {
   contact: ContactDetailType;
@@ -40,7 +40,7 @@ const ContactProfile = ({ contact, plans }: Props) => {
   return (
     <div className='space-y-8'>
       {/* 상단 프로필 + 기본 정보 */}
-      <div className='flex items-start justify-between'>
+      <div className='flex items-start justify-between mt-6'>
         {/* 좌측 - 프로필 이미지 */}
         <div className='relative flex items-center space-x-[-10px]'>
           <div className='relative h-24 w-24 flex-shrink-0 overflow-hidden rounded-full bg-gray-200'>
@@ -48,63 +48,77 @@ const ContactProfile = ({ contact, plans }: Props) => {
               <Image
                 src={contact.contacts_profile_img}
                 alt={contact.name}
-                width={96}
-                height={96}
+                width={124}
+                height={124}
                 className='h-full w-full object-cover'
               />
             ) : (
-              <div className='flex h-full w-full items-center justify-center text-lg font-bold text-white'>
-                <Plus className='absolute left-1/2 top-1/2 h-6 w-6 -translate-x-1/2 -translate-y-1/2' />
+              <div className='flex h-full w-full items-center justify-center text-xl font-bold text-gray-500'>
+                {contact.name.charAt(0)}
               </div>
             )}
           </div>
         </div>
 
         {/* 중앙 - 이름 및 이메일 */}
-        <div className='flex flex-1 flex-col ml-2'>
-          <h1 className='text-xl font-bold leading-tight'>{contact.name}</h1>
-          <div className='mt-1 flex h-6 w-16 items-center justify-center rounded-2xl bg-yellow-300'>
+        <div className='ml-5 flex flex-1 flex-col p-4'>
+          <h1 className='mb-1 text-xl font-bold leading-tight'>{contact.name}</h1>
+          <div className='mt-0.5 flex h-6 w-16 items-center justify-center rounded-2xl bg-yellow-300'>
             <span className='text-xs font-bold text-gray-800'>{contact.relationship_level}</span>
           </div>
-          <p className='text-sm text-gray-600 mt-1'>{contact.email}</p>
+          <p className='mt-2 text-sm text-gray-600'>{contact.email}</p>
         </div>
 
         {/* 우측 버튼 */}
         <div className='space-x-2'>
           <Button variant='outline' size='sm' onClick={() => setIsEditContactOpen(true)}>
-            수정
+            <PencilSimple size={16} />내 사람 수정
           </Button>
           <Button variant='destructive' size='sm' onClick={deleteContactHandler}>
-            삭제
+            <Trash size={16} />내 사람 삭제
           </Button>
         </div>
       </div>
 
+      <div className='border-t border-gray-200' />
+
+      {/* 연락처 + 다가오는 약속 */}
       <div className='flex flex-wrap gap-8'>
         {/* 연락처 정보 */}
-        <div className='min-w-[280px] space-y-2'>
-          <h2 className='mb-2 text-lg font-bold'>연락처</h2>
-          <p>
-            <strong className='inline-block w-20 text-gray-600'>전화번호</strong> {contact.phone}
-          </p>
-          <p>
-            <strong className='inline-block w-20 text-gray-600'>이메일</strong> {contact.email}
-          </p>
-          <p>
-            <strong className='inline-block w-20 text-gray-600'>생년월일</strong> {contact.birth}
-          </p>
-          <p>
-            <strong className='inline-block w-20 text-gray-600'>메모</strong> {contact.notes}
-          </p>
+        <div className='flex-1 space-y-4'>
+          <h2 className='text-xl font-bold text-gray-800 mb-4'>연락처</h2>
+          <div className='space-y-12 text-sm text-gray-700'>
+            <p>
+              <span className='inline-block w-20 font-medium text-base text-gray-500'>전화번호</span>
+              {contact.phone}
+            </p>
+            <p>
+              <span className='inline-block w-20 font-medium text-base text-gray-500'>이메일</span>
+              {contact.email}
+            </p>
+            <p>
+              <span className='inline-block w-20 font-medium text-base text-gray-500'>생년월일</span>
+              {contact.birth}
+            </p>
+            <p>
+              <span className='inline-block w-20 font-medium text-base text-gray-500'>메모</span>
+              {contact.notes}
+            </p>
+          </div>
         </div>
 
         {/* 다가오는 약속 */}
         {plans.length > 0 && (
           <div className='flex-1'>
-            <h2 className='mb-2 text-lg font-bold'>다가오는 약속</h2>
+            <h2 className='text-xl font-bold text-gray-800 mb-4'>다가오는 약속</h2>
             <div className='grid grid-cols-1 gap-4 sm:grid-cols-2'>
               {plans.map((plan) => (
-                <ContactPlansCard key={plan.plan_id} title={plan.title} startDate={plan.start_date} color={plan.colors} />
+                <ContactPlansCard
+                  key={plan.plan_id}
+                  title={plan.title}
+                  startDate={plan.start_date}
+                  color={plan.colors}
+                />
               ))}
             </div>
           </div>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- ex) #110 

<br>

## 📝 작업 내용

> 내 사람 정보 탭 UI 조금 다듬었습니다.
> 후에 2차 시안대로 버튼이나 약속 추가 부분 수정 예정입니다.
> 반응형 디자인 조금 수정했습니다.

<br>

## 
![스크린샷 2025-04-22 144852](https://github.com/user-attachments/assets/edb15eb6-c0b7-4523-ae51-3561598b9da7)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **스타일**
  - 프로필 이미지 크기가 확대되고, 기본 이미지가 연락처 이름의 첫 글자로 변경되었습니다.
  - 프로필 및 연락처 정보 섹션의 레이아웃과 색상, 폰트 크기가 개선되었습니다.
  - 액션 버튼에 아이콘이 추가되어 시각적으로 향상되었습니다.
  - 상단 프로필 영역 하단에 구분선이 추가되었습니다.
  - "연락처" 및 "다가오는 약속" 제목의 스타일이 통일되고 가독성이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->