### PR TITLE
Style/#125 add contact form with side sheet

### DIFF
--- a/src/components/contactDetail/editContactForm/ContactForm.tsx
+++ b/src/components/contactDetail/editContactForm/ContactForm.tsx
@@ -38,7 +38,7 @@ const ContactForm = ({
           <ContactTextField control={form.control} name='name' label='이름' placeholder='이름을 입력해주세요.' />
           <ContactTextField
             control={form.control}
-            name='bio'
+            name='memo'
             label='한줄소개'
             placeholder='이 사람을 한 마디로 표현한다면?'
           />

--- a/src/components/contacts/ContactItem.tsx
+++ b/src/components/contacts/ContactItem.tsx
@@ -15,47 +15,50 @@ const ContactItem = ({ contact, onTogglePin }: ContactItemProps) => {
     e.preventDefault();
     e.stopPropagation();
     onTogglePin(contact.contacts_id, !contact.is_pinned);
-  }
-  
+  };
+
   return (
-    <div className="w-[410px] h-24 flex items-center justify-between border-b border-gray-200 hover:bg-gray-50 cursor-pointer">
+    <div className='flex h-24 w-[410px] cursor-pointer items-center justify-between border-b border-gray-200 hover:bg-gray-50'>
       {/* 내부 상자 - 프로필 및 이름 영역 */}
-      <div className="w-[330px] h-[50px] flex items-center ml-5">
+      <div className='ml-5 flex h-[50px] w-[330px] items-center'>
         {/* 프로필 이미지 */}
-        <div className="h-10 w-10 flex-shrink-0 overflow-hidden rounded-full bg-gray-200">
+        <div className='h-10 w-10 flex-shrink-0 overflow-hidden rounded-full bg-gray-200'>
           {contact.contacts_profile_img ? (
             <Image
               src={contact.contacts_profile_img}
               alt={contact.name}
               width={40}
               height={40}
-              className="h-full w-full object-cover"
+              className='h-full w-full object-cover'
             />
           ) : (
-            <div className="flex h-full w-full items-center justify-center text-lg font-bold text-gray-500">
+            <div className='flex h-full w-full items-center justify-center text-lg font-bold text-gray-500'>
               {contact.name.charAt(0)}
             </div>
           )}
         </div>
 
         {/* 연락처 정보 */}
-        <div className="ml-5 flex flex-col">
-          <h3 className="text-lg font-bold leading-tight text-center">{contact.name}</h3>
-          <div className="w-16 h-6 rounded-2xl bg-yellow-300 flex items-center justify-center mt-0.5">
-            <span className="text-xs font-bold text-gray-800">{contact.relationship_level}</span>
+        <div className='ml-5 flex flex-col items-start'>
+          {/* 뱃지 */}
+          <div className='mb-1 flex h-8 w-[75px] items-center justify-center rounded-2xl bg-yellow-300'>
+            <span className='text-xs font-medium text-gray-800'>{contact.relationship_level}</span>
           </div>
+
+          {/* 이름 */}
+          <h3 className='text-center text-lg font-bold leading-tight'>{contact.name}</h3>
         </div>
       </div>
 
       {/* Pin 버튼 */}
-      <button 
+      <button
         onClick={handlePinClick}
         onMouseEnter={() => setIsPinHovering(true)}
         onMouseLeave={() => setIsPinHovering(false)}
         className={`mr-5 transition-opacity duration-200 ${contact.is_pinned ? 'text-gray-800' : isPinHovering ? 'opacity-70' : 'opacity-20'}`}
-        aria-label={contact.is_pinned ? "즐겨찾기 해제" : "즐겨찾기 추가"}
+        aria-label={contact.is_pinned ? '즐겨찾기 해제' : '즐겨찾기 추가'}
       >
-        <MapPinSimple size={24} weight={contact.is_pinned ? "fill" : "regular"} />
+        <MapPinSimple size={24} weight={contact.is_pinned ? 'fill' : 'regular'} />
       </button>
     </div>
   );

--- a/src/components/contacts/ContactList.tsx
+++ b/src/components/contacts/ContactList.tsx
@@ -52,7 +52,7 @@ const ContactList = ({ onSelectedContact }: ContactListProps) => {
   }
 
   return (
-    <div className='flex h-full flex-col'>
+    <div className='flex h-full flex-col overflow-x-hidden'>
       {/* 헤더 - 내 사람 목록 텍스트 */}
       <h1 className='pl-6 pt-6 text-2xl font-bold'>내 사람 목록</h1>
 

--- a/src/components/contacts/SideSheet.tsx
+++ b/src/components/contacts/SideSheet.tsx
@@ -8,15 +8,15 @@ interface SideSheetProps {
   title?: string; 
 }
 
-const SideSheet = ({ isOpen, onClose, children, title = "내 사람 추가" }: SideSheetProps) => {
-  // 사이드시트가 열릴 때 body에 클래스 추가하여 스크롤 방지
+const SideSheet = ({
+  isOpen,
+  onClose,
+  children,
+  title = "내 사람 추가",
+}: SideSheetProps) => {
+  // 스크롤 방지
   useEffect(() => {
-    if (isOpen) {
-      document.body.classList.add('overflow-hidden');
-    } else {
-      document.body.classList.remove('overflow-hidden');
-    }
-
+    document.body.classList.toggle('overflow-hidden', isOpen);
     return () => {
       document.body.classList.remove('overflow-hidden');
     };
@@ -24,46 +24,38 @@ const SideSheet = ({ isOpen, onClose, children, title = "내 사람 추가" }: S
 
   return (
     <div
-    className={`fixed right-0 top-0 z-50 h-screen w-full transform bg-white shadow-lg transition-all duration-300 ease-in-out border-l border-gray-200 md:w-[474px] ${
-      isOpen ? 'translate-x-0' : 'translate-x-full'
-    }`}
-    style={{
-      transitionProperty: 'transform, box-shadow',
-      boxShadow: isOpen ? '-4px 0 16px rgba(0, 0, 0, 0.1)' : 'none'
-    }}
-  >
-    <div className='flex h-full flex-col p-4'>
-      {/* 스크롤 영역 - 타이틀과 버튼 포함 */}
-      <div 
-        className='flex-1 overflow-y-auto py-4'
-        style={{ scrollbarGutter: 'stable' }}
-      >
-        {/* 타이틀과 버튼도 스크롤 영역 안으로 - 서서히 나타나는 효과 추가 */}
-        <div 
-          className={`flex items-center justify-between mt-2 ml-2 mb-6 transition-opacity duration-500 ${
-            isOpen ? 'opacity-100' : 'opacity-0'
-          }`}
-        >
-          <h2 className='text-2xl font-bold'>{title}</h2>
-          <button 
-            onClick={onClose} 
-            className='rounded-full p-1 hover:bg-gray-100 transition-colors duration-200'
+      className={`
+        fixed right-0 top-0 z-50 h-screen w-full transform
+        bg-white shadow-lg transition-all duration-300 ease-in-out border-l border-gray-200
+        md:w-[474px]
+        ${isOpen ? 'translate-x-0' : 'translate-x-full'}
+      `}
+      style={{
+        transitionProperty: 'transform, box-shadow',
+        boxShadow: isOpen ? '-4px 0 16px rgba(0, 0, 0, 0.1)' : 'none',
+      }}
+    >
+      <div className="flex h-full flex-col">
+        {/* 1) 고정된 타이틀 영역 */}
+        <div className="flex items-center justify-between p-4 border-gray-200">
+          <h2 className="text-2xl font-bold">{title}</h2>
+          <button
+            onClick={onClose}
+            className="rounded-full p-1 hover:bg-gray-100 transition-colors duration-200"
           >
             <X size={24} />
           </button>
         </div>
 
-        {/* 내용이 약간 딜레이되며 페이드인 되도록 설정 */}
-        <div 
-          className={`transition-opacity duration-500 delay-100 ${
-            isOpen ? 'opacity-100' : 'opacity-0'
-          }`}
+        {/* 2) 스크롤이 필요한 children만 이 영역에! */}
+        <div
+          className="flex-1 overflow-y-scroll p-4"
+          style={{ scrollbarGutter: 'stable' }}
         >
           {children}
         </div>
       </div>
     </div>
-  </div>
   );
 };
 

--- a/src/components/contacts/addContactForm/AddContactForm.tsx
+++ b/src/components/contacts/addContactForm/AddContactForm.tsx
@@ -6,7 +6,7 @@ import ContactTextField from './ContactTextField';
 import RelationshipSelector from './RelationshipSelector';
 import ProfileImageUpload from './ProfileImageUpload';
 import { ContactFormValues } from '@/lib/schemas/contactFormSchema';
-import { UsersThree, User, Phone, EnvelopeSimple, Cake, TextAlignLeft } from '@phosphor-icons/react';
+import { User, Phone, EnvelopeSimple, Cake, TextAlignLeft } from '@phosphor-icons/react';
 
 interface AddContactFormProps {
   onClose: () => void;
@@ -31,7 +31,6 @@ const AddContactForm = ({ onClose }: AddContactFormProps) => {
         relationshipType={relationshipType}
         setRelationshipType={setRelationshipType}
         setValue={form.setValue}
-        icon= {<UsersThree size={20} />}
       />
 
       <Form {...form}>

--- a/src/components/contacts/addContactForm/AddContactForm.tsx
+++ b/src/components/contacts/addContactForm/AddContactForm.tsx
@@ -6,6 +6,7 @@ import ContactTextField from './ContactTextField';
 import RelationshipSelector from './RelationshipSelector';
 import ProfileImageUpload from './ProfileImageUpload';
 import { ContactFormValues } from '@/lib/schemas/contactFormSchema';
+import { UsersThree, User, Phone, EnvelopeSimple, Cake, TextAlignLeft } from '@phosphor-icons/react';
 
 interface AddContactFormProps {
   onClose: () => void;
@@ -18,7 +19,7 @@ const AddContactForm = ({ onClose }: AddContactFormProps) => {
   const handleSubmit = async (data: ContactFormValues) => {
     await onSubmit(data);
     onClose(); // 제출 후 사이드 시트 닫기
-  }
+  };
 
   return (
     <div className='space-y-8 pl-12 pr-12'>
@@ -30,6 +31,7 @@ const AddContactForm = ({ onClose }: AddContactFormProps) => {
         relationshipType={relationshipType}
         setRelationshipType={setRelationshipType}
         setValue={form.setValue}
+        icon= {<UsersThree size={20} />}
       />
 
       <Form {...form}>
@@ -41,15 +43,8 @@ const AddContactForm = ({ onClose }: AddContactFormProps) => {
             label='이름'
             placeholder='이름을 입력해주세요.'
             debounceTime={500}
-          />
-
-          {/* 한줄소개 필드 */}
-          <ContactTextField
-            control={form.control}
-            name='bio'
-            label='한줄소개'
-            placeholder='이 사람을 한 마디로 표현한다면?'
-            debounceTime={500}
+            required
+            icon={<User size={20} />}
           />
 
           {/* 전화번호 필드 */}
@@ -61,6 +56,7 @@ const AddContactForm = ({ onClose }: AddContactFormProps) => {
             type='tel'
             maxLength={11} // 최대 11자리로 제한
             debounceTime={500}
+            icon={<Phone size={20} />}
           />
 
           {/* 이메일 필드 */}
@@ -71,10 +67,21 @@ const AddContactForm = ({ onClose }: AddContactFormProps) => {
             placeholder='이메일을 입력해주세요.'
             type='email'
             debounceTime={500}
+            icon={<EnvelopeSimple size={20} />}
           />
 
           {/* 생일 필드 */}
-          <ContactTextField control={form.control} name='birthday' label='생일' placeholder='' type='date' />
+          <ContactTextField control={form.control} name='birthday' label='생일' placeholder='' type='date' icon={<Cake size={20} />} />
+
+          {/* 소개 필드 */}
+          <ContactTextField
+            control={form.control}
+            name='bio'
+            label='메모'
+            placeholder='최대 5줄까지 표시됩니다. 5줄 초과시 말줄임표가 표시됩니다.'
+            debounceTime={500}
+            icon={<TextAlignLeft size={20} />}
+          />
 
           {/* 제출 버튼 */}
           <ContactFormSubmitButton isSubmitting={isSubmitting} />

--- a/src/components/contacts/addContactForm/AddContactForm.tsx
+++ b/src/components/contacts/addContactForm/AddContactForm.tsx
@@ -6,7 +6,8 @@ import ContactTextField from './ContactTextField';
 import RelationshipSelector from './RelationshipSelector';
 import ProfileImageUpload from './ProfileImageUpload';
 import { ContactFormValues } from '@/lib/schemas/contactFormSchema';
-import { User, Phone, EnvelopeSimple, Cake, TextAlignLeft } from '@phosphor-icons/react';
+import { User, Phone, EnvelopeSimple, Cake } from '@phosphor-icons/react';
+import { ContactMemoField } from './ContactMemoField';
 
 interface AddContactFormProps {
   onClose: () => void;
@@ -72,14 +73,9 @@ const AddContactForm = ({ onClose }: AddContactFormProps) => {
           {/* 생일 필드 */}
           <ContactTextField control={form.control} name='birthday' label='생일' placeholder='' type='date' icon={<Cake size={24} />} />
 
-          {/* 소개 필드 */}
-          <ContactTextField
+          {/* 메모 필드 */}
+          <ContactMemoField
             control={form.control}
-            name='bio'
-            label='메모'
-            placeholder='최대 5줄까지 표시됩니다. 5줄 초과시 말줄임표가 표시됩니다.'
-            debounceTime={500}
-            icon={<TextAlignLeft size={24} />}
           />
 
           {/* 제출 버튼 */}

--- a/src/components/contacts/addContactForm/AddContactForm.tsx
+++ b/src/components/contacts/addContactForm/AddContactForm.tsx
@@ -43,7 +43,7 @@ const AddContactForm = ({ onClose }: AddContactFormProps) => {
             placeholder='이름을 입력해주세요.'
             debounceTime={500}
             required
-            icon={<User size={20} />}
+            icon={<User size={24} />}
           />
 
           {/* 전화번호 필드 */}
@@ -55,7 +55,7 @@ const AddContactForm = ({ onClose }: AddContactFormProps) => {
             type='tel'
             maxLength={11} // 최대 11자리로 제한
             debounceTime={500}
-            icon={<Phone size={20} />}
+            icon={<Phone size={24} />}
           />
 
           {/* 이메일 필드 */}
@@ -66,11 +66,11 @@ const AddContactForm = ({ onClose }: AddContactFormProps) => {
             placeholder='이메일을 입력해주세요.'
             type='email'
             debounceTime={500}
-            icon={<EnvelopeSimple size={20} />}
+            icon={<EnvelopeSimple size={24} />}
           />
 
           {/* 생일 필드 */}
-          <ContactTextField control={form.control} name='birthday' label='생일' placeholder='' type='date' icon={<Cake size={20} />} />
+          <ContactTextField control={form.control} name='birthday' label='생일' placeholder='' type='date' icon={<Cake size={24} />} />
 
           {/* 소개 필드 */}
           <ContactTextField
@@ -79,7 +79,7 @@ const AddContactForm = ({ onClose }: AddContactFormProps) => {
             label='메모'
             placeholder='최대 5줄까지 표시됩니다. 5줄 초과시 말줄임표가 표시됩니다.'
             debounceTime={500}
-            icon={<TextAlignLeft size={20} />}
+            icon={<TextAlignLeft size={24} />}
           />
 
           {/* 제출 버튼 */}

--- a/src/components/contacts/addContactForm/ContactMemoField.tsx
+++ b/src/components/contacts/addContactForm/ContactMemoField.tsx
@@ -1,0 +1,46 @@
+// components/contacts/ContactMemoField.tsx
+import React from 'react'
+import { FormField, FormControl, FormMessage } from '@/components/ui/form'
+import { TextAlignLeft } from '@phosphor-icons/react'
+import type { Control } from 'react-hook-form'
+import { ContactFormValues } from '@/lib/schemas/contactFormSchema'
+import { Textarea } from '@/components/ui/textarea'
+
+type ContactMemoFieldProps = {
+  control: Control<ContactFormValues>
+}
+
+export const ContactMemoField: React.FC<ContactMemoFieldProps> = ({ control }) => (
+  <FormField
+    control={control}
+    name="bio"
+    render={({ field, fieldState }) => (
+      <div className="flex w-full items-start">
+        {/* 아이콘 + 라벨 */}
+        <div className="w-24 flex flex-col items-center pt-1">
+          <TextAlignLeft size={24} className="mb-1 text-gray-600" />
+          <div className="text-sm">메모</div>
+        </div>
+
+        {/* textarea */}
+        <div className="flex-1 flex flex-col">
+          <FormControl>
+            <Textarea
+              {...field}
+              rows={5}
+              placeholder="최대 5줄까지 입력 가능합니다."
+              className="resize-none"
+            />
+          </FormControl>
+          <div className="mt-1 min-h-[24px]">
+            {fieldState.error && (
+              <FormMessage className="text-left text-sm text-red-500">
+                {fieldState.error.message}
+              </FormMessage>
+            )}
+          </div>
+        </div>
+      </div>
+    )}
+  />
+)

--- a/src/components/contacts/addContactForm/ContactMemoField.tsx
+++ b/src/components/contacts/addContactForm/ContactMemoField.tsx
@@ -28,7 +28,8 @@ export const ContactMemoField = ({ control }: ContactMemoFieldProps) => (
             <Textarea
               {...field}
               rows={5}
-              placeholder="최대 5줄까지 입력 가능합니다."
+              maxLength={80}
+              placeholder="최대 80글자 까지 입력 가능합니다."
               className="resize-none"
             />
           </FormControl>

--- a/src/components/contacts/addContactForm/ContactMemoField.tsx
+++ b/src/components/contacts/addContactForm/ContactMemoField.tsx
@@ -10,10 +10,10 @@ type ContactMemoFieldProps = {
   control: Control<ContactFormValues>
 }
 
-export const ContactMemoField: React.FC<ContactMemoFieldProps> = ({ control }) => (
+export const ContactMemoField = ({ control }: ContactMemoFieldProps) => (
   <FormField
     control={control}
-    name="bio"
+    name="memo"
     render={({ field, fieldState }) => (
       <div className="flex w-full items-start">
         {/* 아이콘 + 라벨 */}

--- a/src/components/contacts/addContactForm/ContactTextField.tsx
+++ b/src/components/contacts/addContactForm/ContactTextField.tsx
@@ -69,10 +69,10 @@ const ContactTextField = ({
           {/* 왼쪽: 아이콘 + 라벨 */}
           <div className='w-24 flex flex-col items-center pt-1'>
             {icon && <div className='mb-1 text-gray-600'>{icon}</div>}
-            <FormLabel className='text-sm text-center'>
+            <div className='text-sm text-center peer-invalid:text-gray-600'>
               {label}
               {required && <span className='ml-1 text-red-500'>*</span>}
-            </FormLabel>
+            </div>
           </div>
 
           {/* 오른쪽: 인풋 + 에러 */}

--- a/src/components/contacts/addContactForm/ContactTextField.tsx
+++ b/src/components/contacts/addContactForm/ContactTextField.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { Control } from 'react-hook-form';
-import { FormField, FormControl, FormLabel, FormMessage } from '@/components/ui/form';
+import { FormField, FormControl, FormMessage } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { ContactFormValues } from '@/lib/schemas/contactFormSchema';
 

--- a/src/components/contacts/addContactForm/ContactTextField.tsx
+++ b/src/components/contacts/addContactForm/ContactTextField.tsx
@@ -13,20 +13,30 @@ interface ContactTextFieldProps {
   maxLength?: number;
   debounceTime?: number;
   required?: boolean;
+  icon?: React.ReactNode;
 }
 
-const ContactTextField = ({ control, name, label, placeholder, type = 'text', maxLength, debounceTime = 500, required= false }: ContactTextFieldProps) => {
+const ContactTextField = ({
+  control,
+  name,
+  label,
+  placeholder,
+  type = 'text',
+  maxLength,
+  debounceTime = 500,
+  required = false,
+  icon,
+}: ContactTextFieldProps) => {
   const [isTyping, setIsTyping] = useState(false);
   const debounceTimerRef = useRef<NodeJS.Timeout | null>(null);
 
-  // 컴포넌트 언마운트 시 타이머 클리어
-      useEffect(() => {
-        return () => {
-          if (debounceTimerRef.current) {
-            clearTimeout(debounceTimerRef.current);
-          }
-        };
-      }, []);
+  useEffect(() => {
+    return () => {
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+      }
+    };
+  }, []);
 
   return (
     <FormField
@@ -34,43 +44,43 @@ const ContactTextField = ({ control, name, label, placeholder, type = 'text', ma
     name={name}
     render={({ field, fieldState }) => {
       const { error } = fieldState;
-      
+
       const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         setIsTyping(true);
-        
-        // 타이머가 있으면 클리어
         if (debounceTimerRef.current) {
           clearTimeout(debounceTimerRef.current);
         }
-        
-        // 전화번호 필터링
+
         let value = e.target.value;
         if (name === 'phone') {
           value = value.replace(/[^0-9]/g, '');
         }
-        
-        // 값 업데이트
+
         field.onChange(value);
-        
-        // 디바운스 타이머 설정
+
         debounceTimerRef.current = setTimeout(() => {
           setIsTyping(false);
-          // 입력이 멈추면 유효성 검사 트리거 (onBlur 효과)
           field.onBlur();
         }, debounceTime);
       };
-            
+
       return (
-        <div className='flex flex-col'>
-          <div className='flex items-center'>
-            <FormLabel className='w-24 text-lg font-bold'>
+        <div className='flex w-full items-start'>
+          {/* 왼쪽: 아이콘 + 라벨 */}
+          <div className='w-24 flex flex-col items-center pt-1'>
+            {icon && <div className='mb-1 text-gray-600'>{icon}</div>}
+            <FormLabel className='text-sm text-center'>
               {label}
               {required && <span className='ml-1 text-red-500'>*</span>}
             </FormLabel>
-            <FormControl className='flex-1'>
-              <Input 
-                type={type} 
-                placeholder={placeholder} 
+          </div>
+
+          {/* 오른쪽: 인풋 + 에러 */}
+          <div className='flex flex-1 flex-col'>
+            <FormControl>
+              <Input
+                type={type}
+                placeholder={placeholder}
                 maxLength={maxLength}
                 {...field}
                 value={field.value || ''}
@@ -81,17 +91,18 @@ const ContactTextField = ({ control, name, label, placeholder, type = 'text', ma
                 }}
               />
             </FormControl>
-          </div>
-          <div className='mt-1 flex h-6 justify-center'>
-            {/* 타이핑 중이 아닐 때만 에러 메시지 표시 */}
-            {!isTyping && error?.message && (
-              <FormMessage className='text-sm text-red-500'>{error.message}</FormMessage>
-            )}
+
+            {/* 에러 메시지 */}
+            <div className='mt-1 min-h-[24px]'>
+              {!isTyping && error?.message && (
+                <FormMessage className='text-left text-sm text-red-500'>{error.message}</FormMessage>
+              )}
+            </div>
           </div>
         </div>
-      );
-    }}
-  />
+        );
+      }}
+    />
   );
 };
 

--- a/src/components/contacts/addContactForm/ContactTextField.tsx
+++ b/src/components/contacts/addContactForm/ContactTextField.tsx
@@ -66,7 +66,7 @@ const ContactTextField = ({
 
       return (
         <div className='flex w-full items-start'>
-          {/* 왼쪽: 아이콘 + 라벨 */}
+          {/* 아이콘 & 라벨 */}
           <div className='w-24 flex flex-col items-center pt-1'>
             {icon && <div className='mb-1 text-gray-600'>{icon}</div>}
             <div className='text-sm text-center peer-invalid:text-gray-600'>
@@ -75,7 +75,7 @@ const ContactTextField = ({
             </div>
           </div>
 
-          {/* 오른쪽: 인풋 + 에러 */}
+          {/* 인풋 */}
           <div className='flex flex-1 flex-col'>
             <FormControl>
               <Input

--- a/src/components/contacts/addContactForm/RelationshipSelector.tsx
+++ b/src/components/contacts/addContactForm/RelationshipSelector.tsx
@@ -10,6 +10,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { ContactFormValues } from '@/lib/schemas/contactFormSchema';
+import { UsersThree } from '@phosphor-icons/react';
 import React from 'react';
 import { UseFormSetValue } from 'react-hook-form';
 
@@ -17,13 +18,10 @@ interface RelationshipSelectorProps {
   relationshipType: string;
   setRelationshipType: (value: string) => void;
   setValue: UseFormSetValue<ContactFormValues>;
+  icon: React.ReactNode;
 }
 
-const RelationshipSelector = ({
-  relationshipType,
-  setRelationshipType,
-  setValue,
-}: RelationshipSelectorProps) => {
+const RelationshipSelector = ({ relationshipType, setRelationshipType, setValue, icon }: RelationshipSelectorProps) => {
   // 관계 유형 변경 처리
   const handleRelationshipChange = (value: string) => {
     setRelationshipType(value);
@@ -40,8 +38,14 @@ const RelationshipSelector = ({
 
   return (
     <div className='mb-10 mt-10'>
-      <div className='flex items-center'>
-        <div className='w-24 text-lg font-bold'>관계</div>
+      <div className='flex items-start gap-4'>
+        {/* 왼쪽: 아이콘 + 라벨 */}
+        <div className='flex w-24 flex-col items-center'>
+          {icon && <div className='mb-1 text-gray-600'>{icon}</div>}
+          <div className='text-sm'>관계</div>
+        </div>
+
+        {/* 오른쪽: 드롭다운 */}
         <div className='flex-1'>
           <DropdownMenu>
             <DropdownMenuTrigger asChild>

--- a/src/components/contacts/addContactForm/RelationshipSelector.tsx
+++ b/src/components/contacts/addContactForm/RelationshipSelector.tsx
@@ -18,10 +18,9 @@ interface RelationshipSelectorProps {
   relationshipType: string;
   setRelationshipType: (value: string) => void;
   setValue: UseFormSetValue<ContactFormValues>;
-  icon: React.ReactNode;
 }
 
-const RelationshipSelector = ({ relationshipType, setRelationshipType, setValue, icon }: RelationshipSelectorProps) => {
+const RelationshipSelector = ({ relationshipType, setRelationshipType, setValue }: RelationshipSelectorProps) => {
   // 관계 유형 변경 처리
   const handleRelationshipChange = (value: string) => {
     setRelationshipType(value);
@@ -41,7 +40,7 @@ const RelationshipSelector = ({ relationshipType, setRelationshipType, setValue,
       <div className='flex items-start gap-4'>
         {/* 왼쪽: 아이콘 + 라벨 */}
         <div className='flex w-24 flex-col items-center'>
-          {icon && <div className='mb-1 text-gray-600'>{icon}</div>}
+          <UsersThree className='mb-1 text-gray-600' />
           <div className='text-sm'>관계</div>
         </div>
 

--- a/src/components/contacts/addContactForm/RelationshipSelector.tsx
+++ b/src/components/contacts/addContactForm/RelationshipSelector.tsx
@@ -40,7 +40,7 @@ const RelationshipSelector = ({ relationshipType, setRelationshipType, setValue 
       <div className='flex items-start gap-4'>
         {/* 왼쪽: 아이콘 + 라벨 */}
         <div className='flex w-24 flex-col items-center'>
-          <UsersThree className='mb-1 text-gray-600' />
+          <UsersThree size={24} className='mb-1 text-gray-600' />
           <div className='text-sm'>관계</div>
         </div>
 

--- a/src/hooks/mutations/useMutateEditContact.ts
+++ b/src/hooks/mutations/useMutateEditContact.ts
@@ -18,7 +18,7 @@ export const useMutateEditContact = (contactData: ContactDetailType, onClose: ()
     resolver: zodResolver(contactFormSchema),
     defaultValues: {
       name: contactData.name,
-      bio: contactData.notes,
+      memo: contactData.notes,
       phone: contactData.phone,
       email: contactData.email,
       birthday: contactData.birth || '',
@@ -38,7 +38,7 @@ export const useMutateEditContact = (contactData: ContactDetailType, onClose: ()
         user_id: contactData.user_id,
         name: data.name,
         relationship_level: data.relationshipType || '친구',
-        notes: data.bio || '',
+        notes: data.memo || '',
         phone: data.phone || '',
         email: data.email || '',
         birth: data.birthday || '',

--- a/src/hooks/useContactForm.ts
+++ b/src/hooks/useContactForm.ts
@@ -36,7 +36,7 @@ export const useContactForm = () => {
         user_id: userId as string,
         name: data.name.trim(), // 이름 앞뒤 공백 제거
         relationship_level: data.relationshipType || '친구',
-        notes: (data.bio ?? '').trim(),
+        notes: (data.memo ?? '').trim(),
         phone: data.phone || '',
         email: data.email || '',
         birth: data.birthday ? data.birthday : null, // 선택적 필드

--- a/src/lib/schemas/contactFormSchema.ts
+++ b/src/lib/schemas/contactFormSchema.ts
@@ -13,10 +13,10 @@ export const contactFormSchema = z.object({
       message: '숫자만 입력해주세요.',
     })
     .refine((val) => !val || val.length === 0 || val.length <= 11, {
-      message: '전화번호는 최대 11자리까지 입력 가능합니다.',
+      message: '전화번호는 11자리까지 입력 가능합니다.',
     })
     .refine((val) => !val || val.length === 0 || val.length >= 10, {
-      message: '전화번호는 최소 10자리 이상이어야 합니다.',
+      message: '전화번호는 10자리 이상이어야 합니다.',
     }),
   email: z
     .string()

--- a/src/lib/schemas/contactFormSchema.ts
+++ b/src/lib/schemas/contactFormSchema.ts
@@ -7,7 +7,7 @@ export const contactFormSchema = z.object({
   name: z.string()
     .min(1, { message: '이름을 입력해주세요.' })
     .max(13, { message: '이름은 최대 13자까지 입력 가능합니다.' }),
-  bio: z.string().optional(),  // Optional로 변경
+  memo: z.string().optional(),  // Optional로 변경
   phone: z
     .string()
     .optional()
@@ -35,7 +35,7 @@ export const defaultContactFormValues: ContactFormValues = {
   profileImage: '',
   relationshipType: '친구',
   name: '',
-  bio: '',         // Optional 필드여도 초기값은 ''로 설정합니다
+  memo: '',         // Optional 필드여도 초기값은 ''로 설정합니다
   phone: '',
   email: '',
   birthday: '',


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #125 

<br>

## 📝 작업 내용

> 내 사람 추가 버튼을 눌렀을 때 열리는 사이트 시트 내부 UI 변경
input 순서 변경하고 label위에 아이콘 추가
label font size, font weight 변경
한줄소개 인풋을 메모로 변경하고 optional한 값으로 변경

<br>

## 🖼 스크린샷
![스샷](https://github.com/user-attachments/assets/b52bbe35-6779-4f72-866d-fd238995d45a)

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 연락처 추가/수정 폼에 메모 입력란이 추가되었습니다.
    - 연락처 입력란(이름, 전화번호, 이메일, 생일, 관계, 메모)에 아이콘이 추가되어 시각적으로 개선되었습니다.

- **기능 개선**
    - 연락처 폼에서 한 줄 소개(바이오) 입력란이 제거되었습니다.
    - 사이드시트의 헤더(제목, 닫기 버튼)가 고정되고, 스크롤 영역이 분리되어 사용성이 향상되었습니다.
    - 입력란의 레이아웃과 에러 메시지 표시가 개선되었습니다.
    - 전화번호 길이 관련 검증 메시지가 더 간결하게 변경되었습니다.
    - 관계 선택 컴포넌트에 아이콘이 추가되어 UI가 개선되었습니다.
    - 연락처 목록 컴포넌트에 가로 스크롤 방지 스타일이 적용되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->