### PR TITLE
Bugfix/#131 popover more error

### DIFF
--- a/src/app/(pages)/(nav)/calendar/page.tsx
+++ b/src/app/(pages)/(nav)/calendar/page.tsx
@@ -58,7 +58,7 @@ export default function Calendar() {
   const [isEditMode, setIsEditMode] = useState(false); //수정 모드 여부
 
   //옵션 더보기
-  const { initialFormData, setInitialFormData } = usePlanFormStore();
+  const { setInitialFormData } = usePlanFormStore();
   // showPlanForm 상태와 setShowPlanForm 함수 가져오기
   const { showPlanForm, setShowPlanForm } = usePlanFormStore();
   const { mutate: updateEvent } = useUpadateEventMutate();
@@ -252,7 +252,6 @@ export default function Calendar() {
             <h2 className='mb-4 text-xl font-bold'>약속 추가</h2>
             <div className='m-6'>
               <PlanForm
-                initialValues={initialFormData ?? undefined}
                 handleCancel={(show) => {
                   setShowPlanForm(show);
                   setShowUpcoming(true);

--- a/src/components/plans/PlanForm.tsx
+++ b/src/components/plans/PlanForm.tsx
@@ -16,15 +16,10 @@ import { useEffect, useState } from 'react';
 import { toast } from 'react-toastify';
 import ColorOptions from '@/components/calendar/popOver/ColorOptions';
 import { useAuthStore } from '@/store/zustand/store';
-import { usePlanColorStore } from '@/store/zustand/usePlanFormStore';
+import { usePlanColorStore, usePlanFormStore } from '@/store/zustand/usePlanFormStore';
 
-const PlanForm = ({
-  initialValues,
-  handleCancel,
-}: {
-  initialValues?: PlanFormType;
-  handleCancel: (show: boolean) => void;
-}) => {
+const PlanForm = ({ handleCancel }: { handleCancel: (show: boolean) => void }) => {
+  const { initialFormData } = usePlanFormStore();
   const [inputValue, setInputValue] = useState('');
   const { selectedColor, setSelectedColor } = usePlanColorStore(); // 선택 색상
   const user = useAuthStore((state) => state.user);
@@ -34,13 +29,20 @@ const PlanForm = ({
   const form = useForm<PlanFormType>({
     resolver: zodResolver(PlansSchema),
     mode: 'onChange',
-    defaultValues: initialValues ?? planFormDefaultValues, // 초기값을 props로 전달
+    defaultValues: initialFormData ?? planFormDefaultValues, // 초기값을 props로 전달
   });
 
-  // 색상 변경 시 폼의 colors 필드 업데이트
+  // 색상 변경 시 업데이트
   useEffect(() => {
     form.setValue('colors', selectedColor); // 색상 값 업데이트
   }, [selectedColor, form]);
+
+  // 인풋 변경 시 업데이트
+  useEffect(() => {
+    if (initialFormData) {
+      form.reset(initialFormData); // initialFormData가 바뀌면 form을 reset
+    }
+  }, [initialFormData, form]);
 
   // mutate함수 호출
   const { mutate: insertNewPlan } = useMutateInsertNewPlan();


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #131 

<br>

## 📝 작업 내용

> 약속 추가 탭이 열린 상태에서 팝오버의 '옵션 더보기'가 연동되지 않았던 오류 해결했습니다.

<br>

## 🖼 스크린샷
![PPR](https://github.com/user-attachments/assets/34e05912-fa8c-4695-82e3-cfa56039c264)


<br>

## 💬리뷰 요구사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - 플랜 추가 시 PlanForm의 초기값 설정 방식을 개선하여, props 대신 글로벌 상태에서 초기값을 불러오도록 변경되었습니다.  
  - PlanForm 컴포넌트의 불필요한 prop이 제거되어 컴포넌트 사용이 간소화되었습니다.  
  - 초기값 변경 시 폼이 자동으로 초기화되어 더 일관된 사용자 경험을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->