### PR TITLE
Feature/#134 image edit delete in side sheet

### DIFF
--- a/src/components/contacts/addContactForm/AddContactForm.tsx
+++ b/src/components/contacts/addContactForm/AddContactForm.tsx
@@ -8,6 +8,7 @@ import ProfileImageUpload from './ProfileImageUpload';
 import { ContactFormValues } from '@/lib/schemas/contactFormSchema';
 import { User, Phone, EnvelopeSimple, Cake } from '@phosphor-icons/react';
 import { ContactMemoField } from './ContactMemoField';
+import ContactFormCancelButton from './ContactFormCancelButton';
 
 interface AddContactFormProps {
   onClose: () => void;
@@ -72,15 +73,23 @@ const AddContactForm = ({ onClose }: AddContactFormProps) => {
           />
 
           {/* 생일 필드 */}
-          <ContactTextField control={form.control} name='birthday' label='생일' placeholder='' type='date' icon={<Cake size={24} />} />
-
-          {/* 메모 필드 */}
-          <ContactMemoField
+          <ContactTextField
             control={form.control}
+            name='birthday'
+            label='생일'
+            placeholder=''
+            type='date'
+            icon={<Cake size={24} />}
           />
 
-          {/* 제출 버튼 */}
-          <ContactFormSubmitButton isSubmitting={isSubmitting} />
+          {/* 메모 필드 */}
+          <ContactMemoField control={form.control} />
+
+          {/* 버튼 그룹 */}
+          <div className='flex w-full space-x-8'>
+            <ContactFormCancelButton onClose={onClose} />
+            <ContactFormSubmitButton isSubmitting={isSubmitting} />
+          </div>
         </form>
       </Form>
     </div>

--- a/src/components/contacts/addContactForm/ContactFormCancelButton.tsx
+++ b/src/components/contacts/addContactForm/ContactFormCancelButton.tsx
@@ -1,0 +1,21 @@
+import { Button } from '@/components/ui/button';
+import React from 'react';
+
+interface ContactFormCancelButtonProps {
+  onClose: () => void;
+}
+
+const ContactFormCancelButton = ({ onClose }: ContactFormCancelButtonProps) => {
+  return (
+    <Button
+      type='button'
+      onClick={onClose}
+      className='min-h-12 flex-1 border border-grey-500 px-10 py-4 text-center font-bold transition hover:bg-grey-50 active:bg-grey-100'
+      variant='outline'
+    >
+      취소
+    </Button>
+  );
+};
+
+export default ContactFormCancelButton;

--- a/src/components/contacts/addContactForm/ContactFormSubmitButton.tsx
+++ b/src/components/contacts/addContactForm/ContactFormSubmitButton.tsx
@@ -7,11 +7,14 @@ interface ContactFormSubmitButtonProps {
 
 const ContactFormSubmitButton = ({ isSubmitting }: ContactFormSubmitButtonProps) => {
   return (
-    <div className='flex justify-end pt-10'>
-      <Button type='submit' disabled={isSubmitting}>
-        {isSubmitting ? '추가 중...' : '추가'}
-      </Button>
-    </div>
+    <Button
+      type='submit'
+      disabled={isSubmitting}
+      className='min-h-12 flex-1 bg-primary-500 px-10 py-4 text-center font-bold text-grey-0 transition hover:bg-primary-600 active:bg-primary-700'
+      variant='default'
+    >
+      {isSubmitting ? '저장 중...' : '저장'}
+    </Button>
   );
 };
 

--- a/src/components/contacts/addContactForm/ContactTextField.tsx
+++ b/src/components/contacts/addContactForm/ContactTextField.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { ChangeEvent, ReactNode, useEffect, useRef, useState } from 'react';
 import { Control } from 'react-hook-form';
 import { FormField, FormControl, FormMessage } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
@@ -13,7 +13,7 @@ interface ContactTextFieldProps {
   maxLength?: number;
   debounceTime?: number;
   required?: boolean;
-  icon?: React.ReactNode;
+  icon?: ReactNode;
 }
 
 const ContactTextField = ({
@@ -28,41 +28,42 @@ const ContactTextField = ({
   icon,
 }: ContactTextFieldProps) => {
   const [isTyping, setIsTyping] = useState(false);
-  const debounceTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const debounceTimer = useRef<number | null>(null);
 
   useEffect(() => {
     return () => {
-      if (debounceTimerRef.current) {
-        clearTimeout(debounceTimerRef.current);
+      if (debounceTimer.current !== null) {
+        clearTimeout(debounceTimer.current);
       }
     };
   }, []);
 
   return (
     <FormField
-    control={control}
-    name={name}
-    render={({ field, fieldState }) => {
-      const { error } = fieldState;
+      control={control}
+      name={name}
+      render={({ field, fieldState }) => {
+        const { error } = fieldState;
 
-      const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        setIsTyping(true);
-        if (debounceTimerRef.current) {
-          clearTimeout(debounceTimerRef.current);
-        }
+        const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+          setIsTyping(true);
+          // 기존 타이머 취소
+          if (debounceTimer.current !== null) {
+            clearTimeout(debounceTimer.current);
+          }
 
-        let value = e.target.value;
-        if (name === 'phone') {
-          value = value.replace(/[^0-9]/g, '');
-        }
+          let value = e.target.value;
+          if (name === 'phone') {
+            value = value.replace(/[^0-9]/g, '');
+          }
+          field.onChange(value);
 
-        field.onChange(value);
-
-        debounceTimerRef.current = setTimeout(() => {
-          setIsTyping(false);
-          field.onBlur();
-        }, debounceTime);
-      };
+          // 브라우저용 setTimeout은 number를 반환
+          debounceTimer.current = window.setTimeout(() => {
+            setIsTyping(false);
+            field.onBlur();
+          }, debounceTime);
+        };
 
       return (
         <div className='flex w-full items-start'>

--- a/src/components/contacts/addContactForm/ProfileImageUpload.tsx
+++ b/src/components/contacts/addContactForm/ProfileImageUpload.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, useRef } from 'react';
+import React, { useRef } from 'react';
 import { Camera, Pencil, Trash } from 'lucide-react';
 import Image from 'next/image';
 import { UseFormSetValue } from 'react-hook-form';
@@ -13,10 +13,9 @@ interface ProfileImageUploadProps {
 const ProfileImageUpload = ({ imageSource, setImageSource, setValue }: ProfileImageUploadProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const handleFileSelect = (e: ChangeEvent<HTMLInputElement>) => {
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
-
     const reader = new FileReader();
     reader.onload = () => {
       const result = reader.result as string;
@@ -36,12 +35,11 @@ const ProfileImageUpload = ({ imageSource, setImageSource, setValue }: ProfileIm
     if (inputRef.current) inputRef.current.value = '';
   };
 
-  // 이미지가 없을 때 버튼 비활성화
   const disabled = !imageSource;
 
   return (
-    <div className="flex items-center space-x-4 mb-10 mt-10">
-      {/* 파일 인풋 숨기기 */}
+    <div className="flex items-center mb-10 mt-10">
+      {/* 숨긴 파일 인풋 */}
       <input
         type="file"
         accept="image/*"
@@ -53,7 +51,7 @@ const ProfileImageUpload = ({ imageSource, setImageSource, setValue }: ProfileIm
       {/* 이미지 프리뷰 */}
       <label
         onClick={openFileDialog}
-        className="relative h-32 w-32 cursor-pointer flex-shrink-0 rounded-full bg-gray-200 overflow-hidden"
+        className="relative h-40 w-40 cursor-pointer flex-shrink-0 rounded-full bg-gray-200 overflow-hidden"
       >
         {imageSource
           ? <Image src={imageSource} alt="프로필" fill className="object-cover" />
@@ -66,38 +64,47 @@ const ProfileImageUpload = ({ imageSource, setImageSource, setValue }: ProfileIm
         }
       </label>
 
-      {/* 항상 보이되, disabled 처리 */}
-      <div className="flex flex-col space-y-2">
+      <div className="flex flex-col space-y-8 ml-20">
+        {/* 수정 버튼 */}
         <button
           type="button"
           onClick={openFileDialog}
           disabled={disabled}
           title={disabled ? '이미지를 먼저 업로드해주세요' : '이미지 수정'}
           className={`
-            flex items-center rounded-md px-3 py-1 transition
-            ${disabled
-              ? 'opacity-50 cursor-default'
-              : 'hover:bg-gray-100'}
+            flex items-center justify-center
+            w-28 h-8
+            rounded-md
+            bg-primary-500 text-grey-0
+            text-xs
+            font-bold
+            transition
+            ${disabled ? 'opacity-50 cursor-default' : 'hover:bg-primary-600'}
           `}
         >
           <Pencil size={16} className="mr-1" />
-          수정
+          이미지 변경
         </button>
 
+        {/* 삭제 버튼 */}
         <button
           type="button"
           onClick={handleDelete}
           disabled={disabled}
           title={disabled ? '삭제할 이미지가 없습니다' : '이미지 삭제'}
           className={`
-            flex items-center rounded-md px-3 py-1 transition
-            ${disabled
-              ? 'opacity-50 cursor-default text-red-300'
-              : 'hover:bg-gray-100 text-red-500'}
+            flex items-center justify-center
+            w-28 h-8
+            rounded-md
+            bg-primary-50 border border-primary-500 text-primary-500
+            text-xs
+            font-bold
+            transition
+            ${disabled ? 'opacity-50 cursor-default' : 'hover:bg-primary-100'}
           `}
         >
           <Trash size={16} className="mr-1" />
-          삭제
+          이미지 삭제
         </button>
       </div>
     </div>

--- a/src/components/contacts/addContactForm/ProfileImageUpload.tsx
+++ b/src/components/contacts/addContactForm/ProfileImageUpload.tsx
@@ -1,49 +1,104 @@
-import { ContactFormValues } from '@/lib/schemas/contactFormSchema';
-import { Camera } from 'lucide-react';
+import React, { ChangeEvent, useRef } from 'react';
+import { Camera, Pencil, Trash } from 'lucide-react';
 import Image from 'next/image';
-import React from 'react';
 import { UseFormSetValue } from 'react-hook-form';
+import { ContactFormValues } from '@/lib/schemas/contactFormSchema';
 
-interface ProfileImageUPloadProps {
+interface ProfileImageUploadProps {
   imageSource: string | null;
-  setImageSource: (source: string | null) => void;
+  setImageSource: (src: string | null) => void;
   setValue: UseFormSetValue<ContactFormValues>;
 }
 
-const ProfileImageUpload = ({ imageSource, setImageSource, setValue }: ProfileImageUPloadProps) => {
-  // 파일 선택 처리 함수
-  const handleFileSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0];
-    if (file) {
-      const reader = new FileReader();
-      reader.onload = (e) => {
-        const result = e.target?.result as string;
-        setImageSource(e.target?.result as string);
-        setValue('profileImage', result);
-      };
-      reader.readAsDataURL(file);
-    }
+const ProfileImageUpload = ({ imageSource, setImageSource, setValue }: ProfileImageUploadProps) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleFileSelect = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result as string;
+      setImageSource(result);
+      setValue('profileImage', result);
+    };
+    reader.readAsDataURL(file);
   };
 
+  const openFileDialog = () => {
+    inputRef.current?.click();
+  };
+
+  const handleDelete = () => {
+    setImageSource(null);
+    setValue('profileImage', null);
+    if (inputRef.current) inputRef.current.value = '';
+  };
+
+  // 이미지가 없을 때 버튼 비활성화
+  const disabled = !imageSource;
+
   return (
-    <div className='mb-10 mt-10'>
-      <div className='relative'>
-        <input type='file' id='profile-image' accept='image/*' className='hidden' onChange={handleFileSelect} />
-        <label
-          htmlFor='profile-image'
-          className='flex h-32 w-32 cursor-pointer flex-col items-center justify-center rounded-full bg-gray-200'
-        >
-          {imageSource ? (
-            <div className='relative h-full w-full'>
-              <Image src={imageSource} alt='프로필 이미지' fill className='rounded-full object-cover' />
+    <div className="flex items-center space-x-4 mb-10 mt-10">
+      {/* 파일 인풋 숨기기 */}
+      <input
+        type="file"
+        accept="image/*"
+        className="hidden"
+        ref={inputRef}
+        onChange={handleFileSelect}
+      />
+
+      {/* 이미지 프리뷰 */}
+      <label
+        onClick={openFileDialog}
+        className="relative h-32 w-32 cursor-pointer flex-shrink-0 rounded-full bg-gray-200 overflow-hidden"
+      >
+        {imageSource
+          ? <Image src={imageSource} alt="프로필" fill className="object-cover" />
+          : (
+            <div className="flex h-full w-full flex-col items-center justify-center text-gray-500">
+              <Camera className="mb-1 h-6 w-6" />
+              <span className="text-xs font-bold">이미지 추가</span>
             </div>
-          ) : (
-            <>
-              <Camera className='mb-1 h-6 w-6 text-gray-500' />
-              <span className='text-xs font-bold'>이미지 추가</span>
-            </>
-          )}
-        </label>
+          )
+        }
+      </label>
+
+      {/* 항상 보이되, disabled 처리 */}
+      <div className="flex flex-col space-y-2">
+        <button
+          type="button"
+          onClick={openFileDialog}
+          disabled={disabled}
+          title={disabled ? '이미지를 먼저 업로드해주세요' : '이미지 수정'}
+          className={`
+            flex items-center rounded-md px-3 py-1 transition
+            ${disabled
+              ? 'opacity-50 cursor-default'
+              : 'hover:bg-gray-100'}
+          `}
+        >
+          <Pencil size={16} className="mr-1" />
+          수정
+        </button>
+
+        <button
+          type="button"
+          onClick={handleDelete}
+          disabled={disabled}
+          title={disabled ? '삭제할 이미지가 없습니다' : '이미지 삭제'}
+          className={`
+            flex items-center rounded-md px-3 py-1 transition
+            ${disabled
+              ? 'opacity-50 cursor-default text-red-300'
+              : 'hover:bg-gray-100 text-red-500'}
+          `}
+        >
+          <Trash size={16} className="mr-1" />
+          삭제
+        </button>
       </div>
     </div>
   );

--- a/src/components/contacts/addContactForm/ProfileImageUpload.tsx
+++ b/src/components/contacts/addContactForm/ProfileImageUpload.tsx
@@ -1,8 +1,9 @@
 import React, { useRef } from 'react';
-import { Camera, Pencil, Trash } from 'lucide-react';
+import { Pencil, Trash } from 'lucide-react';
 import Image from 'next/image';
 import { UseFormSetValue } from 'react-hook-form';
 import { ContactFormValues } from '@/lib/schemas/contactFormSchema';
+import { ImageSquare } from '@phosphor-icons/react';
 
 interface ProfileImageUploadProps {
   imageSource: string | null;
@@ -57,8 +58,7 @@ const ProfileImageUpload = ({ imageSource, setImageSource, setValue }: ProfileIm
           ? <Image src={imageSource} alt="프로필" fill className="object-cover" />
           : (
             <div className="flex h-full w-full flex-col items-center justify-center text-gray-500">
-              <Camera className="mb-1 h-6 w-6" />
-              <span className="text-xs font-bold">이미지 추가</span>
+              <ImageSquare className="mb-1 h-6 w-6" />
             </div>
           )
         }

--- a/src/lib/schemas/contactFormSchema.ts
+++ b/src/lib/schemas/contactFormSchema.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 // Form Schema Definition
 export const contactFormSchema = z.object({
-  profileImage: z.string().optional(),
+  profileImage: z.string().nullable(),
   relationshipType: z.string().optional(),
   name: z.string()
     .min(1, { message: '이름을 입력해주세요.' })


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #134 

<br>

## 📝 작업 내용

> 내 사람 추가 사이드 시트에서 이미지 업로드 수정, 삭제할 수 있는 버튼 구현
사이드 시트 하단에 사이드 시트를 닫을 수 있는 취소 버튼 추가

<br>

## 🖼 스크린샷
![캡처](https://github.com/user-attachments/assets/4435c75d-56b1-47fb-952e-76b9296e9d5c)

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 연락처 추가 폼에 취소 버튼이 추가되어, 사용자가 폼을 명확하게 취소할 수 있습니다.
- **개선 사항**
	- 프로필 이미지 업로드 UI가 개선되어 이미지 변경 및 삭제 버튼이 분리되고, 접근성과 조작성이 향상되었습니다.
	- 연락처 추가 폼의 저장 버튼 텍스트가 "저장"으로 변경되고 스타일이 개선되었습니다.
- **버그 수정**
	- 프로필 이미지 필드가 null 값을 허용하도록 변경되어 이미지 삭제 시 오류가 발생하지 않습니다.
- **기타**
	- 입력 필드의 디바운스 처리 및 타입 선언이 개선되어 입력 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->