### PR TITLE
Feature/#122 toolbar button dynamic UI

### DIFF
--- a/src/app/(pages)/(nav)/calendar/page.tsx
+++ b/src/app/(pages)/(nav)/calendar/page.tsx
@@ -68,6 +68,9 @@ export default function Calendar() {
   const { showPlanForm, setShowPlanForm } = usePlanFormStore();
   const { mutate: updateEvent } = useUpadateEventMutate();
 
+  // 툴바 버튼 동적
+  const [activeTab, setActiveTab] = useState<'upcoming' | 'add'>('upcoming');
+
   //캘린더 페이지 마운트 후, 로그인 여부 판단
   useEffect(() => {
     setHasMounted(true);
@@ -223,6 +226,7 @@ export default function Calendar() {
           setMoment={setMoment}
           events={combinedEvents}
           onEventDrop={moveEventsHandler}
+          activeTab={activeTab}
           onSelectPlan={(planId) => setSelectedPlanId(planId)}
           setSelectPlan={(plan) => {
             setSelectPlan(plan);
@@ -238,6 +242,7 @@ export default function Calendar() {
               setShowPlanForm(false);
               setIsEditMode(false);
               setEditPlan(null);
+              setActiveTab('upcoming');
             },
             onAddPlan: () => {
               setSelectPlan(null);
@@ -246,6 +251,7 @@ export default function Calendar() {
               setIsEditMode(false);
               setEditPlan(null);
               setInitialFormData(planFormDefaultValues);
+              setActiveTab('add');
             },
           }}
         />

--- a/src/components/calendar/AddPlanButton.tsx
+++ b/src/components/calendar/AddPlanButton.tsx
@@ -10,7 +10,7 @@ const AddPlanButton = ({ onClick, activeTab }: Props) => {
     <div>
       <button
         onClick={onClick}
-        className={`items-center justify-center rounded-md border-[1px] px-5 py-3 text-[14px] font-bold ${activeTab === 'add' ? 'border-primary-500 text-primary-500' : 'border-grey-300'}`}
+        className={`items-center justify-center rounded-md border-[1px] px-5 py-3 text-[14px] font-bold ${activeTab === 'add' ? 'border-primary-500 text-primary-500' : 'border-grey-300 text-grey-700'}`}
       >
         약속 추가
       </button>

--- a/src/components/calendar/AddPlanButton.tsx
+++ b/src/components/calendar/AddPlanButton.tsx
@@ -1,11 +1,16 @@
 import React from 'react';
 
-const AddPlanButton = ({ onClick }: { onClick: () => void }) => {
+interface Props {
+  onClick: () => void;
+  activeTab: string;
+}
+
+const AddPlanButton = ({ onClick, activeTab }: Props) => {
   return (
     <div>
       <button
         onClick={onClick}
-        className='items-center justify-center rounded-md border-[1px] border-primary-500 px-5 py-3 text-[14px] font-bold text-[#0066FF]'
+        className={`items-center justify-center rounded-md border-[1px] px-5 py-3 text-[14px] font-bold ${activeTab === 'add' ? 'border-primary-500 text-primary-500' : 'border-grey-300'}`}
       >
         약속 추가
       </button>

--- a/src/components/calendar/CustomToolbar.tsx
+++ b/src/components/calendar/CustomToolbar.tsx
@@ -9,18 +9,19 @@ import MoveMonthButton from './MoveMonthButton';
 export interface CustomToolbarProps extends ToolbarProps<CalendarEventType> {
   onShowUpcomingPlans: () => void;
   onAddPlan: () => void;
+  activeTab: string;
 }
 
 //캘린더와 타입 맞춤(id 유실로 인한 오류)
-const CustomToolbar = ({ date, onNavigate, onShowUpcomingPlans, onAddPlan }: CustomToolbarProps) => {
+const CustomToolbar = ({ date, onNavigate, onShowUpcomingPlans, onAddPlan, activeTab }: CustomToolbarProps) => {
   const customLabel = format(date, 'yyyy MMMM', { locale: ko });
   return (
     <div className='mt-[18px] flex'>
       <MoveMonthButton onNavigate={onNavigate} />
       <span className='ml-6 text-[28px] font-bold'>{customLabel}</span>
       <section className='mb-[12.5px] ml-auto mr-2 flex'>
-        <UpcomingPlanButton onClick={onShowUpcomingPlans} />
-        <AddPlanButton onClick={onAddPlan} />
+        <UpcomingPlanButton onClick={onShowUpcomingPlans} activeTab={activeTab} />
+        <AddPlanButton onClick={onAddPlan} activeTab={activeTab} />
       </section>
     </div>
   );

--- a/src/components/calendar/MainCalendar.tsx
+++ b/src/components/calendar/MainCalendar.tsx
@@ -20,6 +20,7 @@ interface MainCalendarProps {
     onShowUpcomingPlans: () => void;
     onAddPlan: () => void;
   };
+  activeTab: string;
 }
 
 const localizer = dateFnsLocalizer({
@@ -37,6 +38,7 @@ const MainCalendar = ({
   moment,
   setMoment,
   onEventDrop,
+  activeTab,
 }: MainCalendarProps) => {
   const [selectedDate, setSelectedDate] = useState<Date | null>(null); //선택한 셀 날짜
   const [isPopOverOpen, setIsPopOverOpen] = useState(false); //팝오버 오픈 여부
@@ -44,7 +46,7 @@ const MainCalendar = ({
   const DnDCalendar = withDragAndDrop<CalendarEventType>(Calendar); //DnD 사용 캘린더
 
   return (
-    <div>
+    <div className='h-screen'>
       <DnDCalendar
         selectable
         localizer={localizer}
@@ -59,7 +61,7 @@ const MainCalendar = ({
         defaultView='month'
         views={['month']}
         components={{
-          toolbar: (props) => <CustomToolbar {...props} {...CustomToolbarProps} />, // 상단 툴바(달 이동)
+          toolbar: (props) => <CustomToolbar {...props} {...CustomToolbarProps} activeTab={activeTab} />, // 상단 툴바(달 이동)
           month: {
             dateHeader: CustomDateHeader, // 날짜 셀의 숫자
           },
@@ -70,7 +72,7 @@ const MainCalendar = ({
           setIsPopOverOpen(true); // 모달 열기
         }}
         onSelectEvent={(event) => onSelectPlan(event.id)}
-        style={{ height: '100vh' }}
+        className='h-full'
       />
       {isPopOverOpen && selectedDate && (
         <CalendarPopOver open={isPopOverOpen} onOpenChange={setIsPopOverOpen} date={selectedDate} />

--- a/src/components/calendar/UpcomingPlanButton.tsx
+++ b/src/components/calendar/UpcomingPlanButton.tsx
@@ -2,7 +2,12 @@ import { getUserPlans } from '@/app/api/supabase/service';
 import { useAuthStore } from '@/store/zustand/store';
 import React, { useEffect, useState } from 'react';
 
-const UpcomingPlanButton = ({ onClick }: { onClick: () => void }) => {
+interface Props {
+  onClick: () => void;
+  activeTab: string;
+}
+
+const UpcomingPlanButton = ({ onClick, activeTab }: Props) => {
   const user = useAuthStore((state) => state.user);
   const [upcomingCount, setUpcomingCount] = useState<number | null>(null);
 
@@ -18,10 +23,13 @@ const UpcomingPlanButton = ({ onClick }: { onClick: () => void }) => {
 
   return (
     <div>
-      <button onClick={onClick} className='mr-6 rounded-md border-[1px] px-5 py-3 text-[14px] font-bold'>
+      <button
+        onClick={onClick}
+        className={`mr-6 rounded-md border-[1px] px-5 py-3 text-[14px] font-bold ${activeTab === 'upcoming' ? 'border-primary-500 text-primary-500' : 'border-grey-300'}`}
+      >
         다가오는 약속
-        <span className='m-1 rounded-full bg-black px-1 text-white'>
-          {upcomingCount !== null ? upcomingCount : '-'}
+        <span className={`m-1 rounded-full px-1 text-white ${activeTab === 'upcoming' ? 'bg-[#0066FF]' : 'bg-black'}`}>
+          {upcomingCount !== null ? upcomingCount : ''}
         </span>
       </button>
     </div>

--- a/src/components/calendar/UpcomingPlanButton.tsx
+++ b/src/components/calendar/UpcomingPlanButton.tsx
@@ -25,7 +25,7 @@ const UpcomingPlanButton = ({ onClick, activeTab }: Props) => {
     <div>
       <button
         onClick={onClick}
-        className={`mr-6 rounded-md border-[1px] px-5 py-3 text-[14px] font-bold ${activeTab === 'upcoming' ? 'border-primary-500 text-primary-500' : 'border-grey-300'}`}
+        className={`mr-6 rounded-md border-[1px] px-5 py-3 text-[14px] font-bold ${activeTab === 'upcoming' ? 'border-primary-500 text-primary-500' : 'border-grey-300 text-grey-700'}`}
       >
         다가오는 약속
         <span className={`m-1 rounded-full px-1 text-white ${activeTab === 'upcoming' ? 'bg-[#0066FF]' : 'bg-black'}`}>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #122 

<br>

## 📝 작업 내용

> 캘린더 페이지에서 동적 state 생성 후 툴바 버튼에 전달, 동적 UI 구현하였습니다.

<br>

## 🖼 스크린샷
![PR](https://github.com/user-attachments/assets/68f0b6ee-354a-4297-ab36-bc548aafbc49)


<br>

## 💬리뷰 요구사항



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 캘린더 툴바에 '예정된 일정'과 '일정 추가' 탭 전환 기능이 추가되어, 현재 활성화된 탭에 따라 버튼 스타일이 동적으로 변경됩니다.

- **스타일**
    - 캘린더 및 버튼의 스타일이 활성 탭 상태에 따라 동적으로 적용되며, 캘린더 높이 스타일이 Tailwind CSS 유틸리티 클래스로 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->