### PR TITLE
Featurue/#149 red days

### DIFF
--- a/src/app/(pages)/(nav)/calendar/page.tsx
+++ b/src/app/(pages)/(nav)/calendar/page.tsx
@@ -227,6 +227,7 @@ export default function Calendar() {
           events={combinedEvents}
           onEventDrop={moveEventsHandler}
           activeTab={activeTab}
+          holidays={holidays}
           onSelectPlan={(planId) => setSelectedPlanId(planId)}
           setSelectPlan={(plan) => {
             setSelectPlan(plan);

--- a/src/components/calendar/CustomDateHeader.tsx
+++ b/src/components/calendar/CustomDateHeader.tsx
@@ -8,7 +8,7 @@ interface Props {
 
 export const CustomDateHeader = ({ label, date, holidays }: Props) => {
   const isSunday = getDay(date) === 0;
-  const isHoliday = holidays.some((h) => isSameDay(new Date(h.date), date)); //isSameDay: 같은 날짜인지 확인
+  const isHoliday = (holidays ?? []).some((h) => isSameDay(new Date(h.date), date)); //isSameDay: 같은 날짜인지 확인
 
   return (
     <div className={`pl-1 text-left ${isSunday || isHoliday ? 'text-red-500' : 'text-grey-800'}`}>

--- a/src/components/calendar/CustomDateHeader.tsx
+++ b/src/components/calendar/CustomDateHeader.tsx
@@ -1,5 +1,18 @@
-export const CustomDateHeader = ({ label }: { label: string }) => (
-  <div style={{ textAlign: 'left', paddingLeft: '4px' }}>
-    <span>{label}</span>
-  </div>
-);
+import { getDay, isSameDay } from 'date-fns';
+
+interface Props {
+  label: string;
+  date: Date;
+  holidays: { date: string; title: string }[];
+}
+
+export const CustomDateHeader = ({ label, date, holidays }: Props) => {
+  const isSunday = getDay(date) === 0;
+  const isHoliday = holidays.some((h) => isSameDay(new Date(h.date), date)); //isSameDay: 같은 날짜인지 확인
+
+  return (
+    <div className={`pl-1 text-left ${isSunday || isHoliday ? 'text-red-500' : 'text-grey-800'}`}>
+      <span>{label}</span>
+    </div>
+  );
+};

--- a/src/components/calendar/MainCalendar.tsx
+++ b/src/components/calendar/MainCalendar.tsx
@@ -65,7 +65,7 @@ const MainCalendar = ({
         components={{
           toolbar: (props) => <CustomToolbar {...props} {...CustomToolbarProps} activeTab={activeTab} />, // 상단 툴바(달 이동)
           month: {
-            dateHeader: (props) => <CustomDateHeader {...props} holidays={holidays} />, // 날짜 셀의 숫자
+            dateHeader: (props) => <CustomDateHeader {...props} holidays={holidays ?? []} />, // 날짜 셀의 숫자
           },
         }}
         eventPropGetter={holidayStyle}

--- a/src/components/calendar/MainCalendar.tsx
+++ b/src/components/calendar/MainCalendar.tsx
@@ -21,6 +21,7 @@ interface MainCalendarProps {
     onAddPlan: () => void;
   };
   activeTab: string;
+  holidays: { date: string; title: string }[];
 }
 
 const localizer = dateFnsLocalizer({
@@ -39,6 +40,7 @@ const MainCalendar = ({
   setMoment,
   onEventDrop,
   activeTab,
+  holidays,
 }: MainCalendarProps) => {
   const [selectedDate, setSelectedDate] = useState<Date | null>(null); //선택한 셀 날짜
   const [isPopOverOpen, setIsPopOverOpen] = useState(false); //팝오버 오픈 여부
@@ -63,7 +65,7 @@ const MainCalendar = ({
         components={{
           toolbar: (props) => <CustomToolbar {...props} {...CustomToolbarProps} activeTab={activeTab} />, // 상단 툴바(달 이동)
           month: {
-            dateHeader: CustomDateHeader, // 날짜 셀의 숫자
+            dateHeader: (props) => <CustomDateHeader {...props} holidays={holidays} />, // 날짜 셀의 숫자
           },
         }}
         eventPropGetter={holidayStyle}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #149 

<br>

## 📝 작업 내용

> 캘린더에서 일요일과 공휴일 날짜를 빨간색으로 나타냅니다.

<br>

## 🖼 스크린샷
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/408fc50c-3306-452e-96c9-f1f12944f78c" />

<br>

## 💬리뷰 요구사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 캘린더 툴바 버튼이 현재 활성화된 탭(예정 일정/일정 추가)에 따라 동적으로 스타일이 변경됩니다.
    - 달력 헤더가 일요일 또는 공휴일에 빨간색으로 표시됩니다.
    - 캘린더에 공휴일 정보가 통합되어 날짜별로 시각적으로 구분됩니다.

- **스타일**
    - 버튼과 캘린더, 헤더에 Tailwind CSS 기반의 동적 스타일이 적용되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->