### PR TITLE
Style/#155 overlay in sidesheet

### DIFF
--- a/src/components/contacts/ContactItem.tsx
+++ b/src/components/contacts/ContactItem.tsx
@@ -18,13 +18,13 @@ const ContactItem = ({ contact, onTogglePin, isSelected = false }: ContactItemPr
   };
 
   return (
-    <div  className={`flex h-24 w-full cursor-pointer items-center justify-between border-b border-gray-200 ${
-      isSelected ? 'bg-gray-200' : 'hover:bg-gray-50'
+    <div  className={`flex h-24 w-full cursor-pointer items-center justify-between border-b border-grey-50 ${
+      isSelected ? 'bg-grey-50' : 'hover:bg-grey-50'
     }`}>
       {/* 내부 상자 - 프로필 및 이름 영역 */}
       <div className='ml-5 flex h-[50px] w-[330px] items-center'>
         {/* 프로필 이미지 */}
-        <div className='h-10 w-10 flex-shrink-0 overflow-hidden rounded-full bg-gray-200'>
+        <div className='h-10 w-10 flex-shrink-0 overflow-hidden rounded-full bg-grey-100'>
           {contact.contacts_profile_img ? (
             <Image
               src={contact.contacts_profile_img}
@@ -34,7 +34,7 @@ const ContactItem = ({ contact, onTogglePin, isSelected = false }: ContactItemPr
               className='h-full w-full object-cover'
             />
           ) : (
-            <div className='flex h-full w-full items-center justify-center text-lg font-bold text-gray-500'>
+            <div className='flex h-full w-full items-center justify-center text-lg font-bold text-grey-500'>
               {contact.name.charAt(0)}
             </div>
           )}
@@ -43,7 +43,7 @@ const ContactItem = ({ contact, onTogglePin, isSelected = false }: ContactItemPr
         {/* 연락처 정보 */}
         <div className='ml-5 flex flex-col items-start'>
           {/* 뱃지 */}
-          <div className='mb-1 flex h-8 w-[75px] items-center justify-center rounded-2xl bg-yellow-300'>
+          <div className='mb-1 flex h-8 w-[75px] items-center justify-center rounded-2xl bg-secondary-500'>
             <span className='text-xs font-medium text-gray-800'>{contact.relationship_level}</span>
           </div>
 
@@ -57,7 +57,7 @@ const ContactItem = ({ contact, onTogglePin, isSelected = false }: ContactItemPr
         onClick={handlePinClick}
         onMouseEnter={() => setIsPinHovering(true)}
         onMouseLeave={() => setIsPinHovering(false)}
-        className={`mr-5 transition-opacity duration-200 ${contact.is_pinned ? 'text-gray-800' : isPinHovering ? 'opacity-70' : 'opacity-20'}`}
+        className={`mr-5 transition-opacity duration-200 ${contact.is_pinned ? 'text-grey-800' : isPinHovering ? 'opacity-70' : 'opacity-20'}`}
         aria-label={contact.is_pinned ? '즐겨찾기 해제' : '즐겨찾기 추가'}
       >
         <MapPinSimple size={24} weight={contact.is_pinned ? 'fill' : 'regular'} />

--- a/src/components/contacts/ContactList.tsx
+++ b/src/components/contacts/ContactList.tsx
@@ -101,7 +101,7 @@ export default function ContactList({ peopleSelectedId ,onSelectedContact }: Con
       {/* 추가 버튼 */}
       <div className='mt-12 flex justify-center'>
         <button
-          className='flex h-12 w-full max-w-sm items-center justify-center rounded-lg border border-gray-300 font-medium text-gray-700 transition-colors hover:bg-gray-100'
+          className='flex h-12 w-full max-w-sm items-center justify-center rounded-lg border border-grey-50 font-medium text-grey-50 transition-colors bg-primary-500 hover:bg-primary-600'
           onClick={() => setIsAddContactOpen(true)}
         >
           <UserPlus size={20} className='mr-2' />
@@ -118,8 +118,8 @@ export default function ContactList({ peopleSelectedId ,onSelectedContact }: Con
             {/* 핀된 연락처 */}
             {(isDemoUser ? demoPinned : pinnedContacts).length > 0 && (
               <section className='mb-6'>
-                <div className='flex items-center bg-gray-50 px-6 py-3'>
-                  <h2 className='text-sm font-semibold text-gray-700'>고정됨</h2>
+                <div className='flex items-center px-6 py-3'>
+                  <h2 className='text-sm font-semibold text-grey-700'>고정됨</h2>
                 </div>
                 <ul className='flex flex-col'>
                   {(isDemoUser ? demoPinned : pinnedContacts).map((c) => (
@@ -136,8 +136,8 @@ export default function ContactList({ peopleSelectedId ,onSelectedContact }: Con
             {/* 일반 연락처 */}
             <section>
               {(isDemoUser ? demoRegular : regularContacts).length > 0 && (
-                <div className='flex items-center bg-gray-50 px-6 py-3'>
-                  <h2 className='text-sm font-semibold text-gray-700'>리스트</h2>
+                <div className='flex items-center px-6 py-3'>
+                  <h2 className='text-sm font-semibold text-grey-700'>리스트</h2>
                 </div>
               )}
               <ul className='flex flex-col'>
@@ -153,7 +153,7 @@ export default function ContactList({ peopleSelectedId ,onSelectedContact }: Con
               {/* 무한 스크롤 트리거 */}
               {!isDemoUser && (
                 <div ref={loadMoreRef} className='flex justify-center py-4'>
-                  {isFetchingNextPage && <div className='text-sm text-gray-500'>연락처를 더 불러오는 중...</div>}
+                  {isFetchingNextPage && <div className='text-sm text-grey-500'>연락처를 더 불러오는 중...</div>}
                 </div>
               )}
             </section>

--- a/src/components/contacts/SideSheet.tsx
+++ b/src/components/contacts/SideSheet.tsx
@@ -23,6 +23,14 @@ const SideSheet = ({
   }, [isOpen]);
 
   return (
+   <>
+   {/* 오버레이 */}
+   {isOpen && (
+    <div
+      className='fixed inset-0 bg-black bg-opacity-40 z-40'
+      onClick={onClose}
+    />
+   )}
     <div
       className={`
         fixed right-0 top-0 z-50 h-screen w-full transform
@@ -56,6 +64,7 @@ const SideSheet = ({
         </div>
       </div>
     </div>
+   </>
   );
 };
 

--- a/src/components/contacts/SideSheet.tsx
+++ b/src/components/contacts/SideSheet.tsx
@@ -34,7 +34,7 @@ const SideSheet = ({
     <div
       className={`
         fixed right-0 top-0 z-50 h-screen w-full transform
-        bg-white shadow-lg transition-all duration-300 ease-in-out border-l border-gray-200
+        bg-white shadow-lg transition-all duration-300 ease-in-out border-l border-grey-200
         md:w-[474px]
         ${isOpen ? 'translate-x-0' : 'translate-x-full'}
       `}
@@ -45,11 +45,11 @@ const SideSheet = ({
     >
       <div className="flex h-full flex-col">
         {/* 1) 고정된 타이틀 영역 */}
-        <div className="flex items-center justify-between p-4 border-gray-200">
+        <div className="flex items-center justify-between p-4 border-grey-200">
           <h2 className="text-2xl font-bold">{title}</h2>
           <button
             onClick={onClose}
-            className="rounded-full p-1 hover:bg-gray-100 transition-colors duration-200"
+            className="rounded-full p-1 hover:bg-grey-100 transition-colors duration-200"
           >
             <X size={24} />
           </button>

--- a/src/components/contacts/addContactForm/ContactTextField.tsx
+++ b/src/components/contacts/addContactForm/ContactTextField.tsx
@@ -69,8 +69,8 @@ const ContactTextField = ({
         <div className='flex w-full items-start'>
           {/* 아이콘 & 라벨 */}
           <div className='w-24 flex flex-col items-center pt-1'>
-            {icon && <div className='mb-1 text-gray-600'>{icon}</div>}
-            <div className='text-sm text-center peer-invalid:text-gray-600'>
+            {icon && <div className='mb-1 text-grey-600'>{icon}</div>}
+            <div className='text-sm text-center peer-invalid:text-grey-600'>
               {label}
               {required && <span className='ml-1 text-red-500'>*</span>}
             </div>

--- a/src/components/contacts/addContactForm/ProfileImageUpload.tsx
+++ b/src/components/contacts/addContactForm/ProfileImageUpload.tsx
@@ -52,12 +52,12 @@ const ProfileImageUpload = ({ imageSource, setImageSource, setValue }: ProfileIm
       {/* 이미지 프리뷰 */}
       <label
         onClick={openFileDialog}
-        className="relative h-40 w-40 cursor-pointer flex-shrink-0 rounded-full bg-gray-200 overflow-hidden"
+        className="relative h-40 w-40 cursor-pointer flex-shrink-0 rounded-full bg-grey-100 overflow-hidden"
       >
         {imageSource
           ? <Image src={imageSource} alt="프로필" fill className="object-cover" />
           : (
-            <div className="flex h-full w-full flex-col items-center justify-center text-gray-500">
+            <div className="flex h-full w-full flex-col items-center justify-center text-black">
               <ImageSquare className="mb-1 h-6 w-6" />
             </div>
           )

--- a/src/components/schedule/UpcomingPlanCard.tsx
+++ b/src/components/schedule/UpcomingPlanCard.tsx
@@ -2,15 +2,14 @@
 
 import React from 'react';
 import { PlansType } from '@/types/plans';
-import { formatDateShort, isToday, calculateDday } from '@/lib/utils/dateUtils';
+import { formatDateShort, calculateDday } from '@/lib/utils/dateUtils';
 
 interface UpcomingPlanCardProps {
   plan: PlansType;
 }
 
 const UpcomingPlanCard = ({ plan }: UpcomingPlanCardProps) => {
-  const todayPlan = isToday(plan.start_date);
-
+  
   return (
     <div className="relative flex h-36 w-96 rounded-lg border shadow-sm transition-all hover:shadow-md overflow-hidden">
       {/* 왼쪽 색상 막대 추가 */}
@@ -19,11 +18,9 @@ const UpcomingPlanCard = ({ plan }: UpcomingPlanCardProps) => {
         style={{ backgroundColor: plan.colors }}
       />
       
-      <div className={`flex-1 p-4 ${
-        todayPlan ? 'bg-[#FFF4C7]' : ''
-      }`}>
+      <div className={'flex-1 p-4'}>
         {/* 상단에 날짜 표시 */}
-        <div className='text-md mb-2 font-medium text-gray-500'>
+        <div className='text-md mb-2 font-medium text-grey-500'>
           {formatDateShort(plan.start_date)}
         </div>
 

--- a/src/components/schedule/UpcomingPlans.tsx
+++ b/src/components/schedule/UpcomingPlans.tsx
@@ -34,8 +34,8 @@ const UpcomingPlans = ({ userId, onSelectPlan }: UpcomingPlansProps) => {
     return <div className='p-4 text-center'>향후 30일 내에 예정된 일정이 없습니다.</div>;
 
   return (
-    <div className='max-h-[calc(100vh-2rem)] space-y-4 overflow-auto'>
-      <h2 className='mb-4 text-xl font-bold'>다가오는 일정</h2>
+    <div className='max-h-[calc(100vh-2rem)] space-y-4 overflow-visible'>
+      <h2 className='mb-4 text-xl font-bold'>다가오는 약속</h2>
       <div className='space-y-3'>
         {plans.map((plan) => (
           <div key={plan.plan_id} onClick={() => onSelectPlan(plan)} className='cursor-pointer'>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- ex) #이슈번호, #이슈번호

<br>

## 📝 작업 내용

> 내 사람 추가, 수정, 약속 추가에 사용되는 SideSheet 컴포넌트가 열릴 때 왼쪽에 오버레이를 구현
tailwind css 에서 제공하는 컬러대신 따로 커스텀한 컬러로 변경
내 사람 추가 버튼, 리스트, 아이템, AddcontactForm 등 색 변경

<br>

## 🖼 스크린샷
![스샷](https://github.com/user-attachments/assets/b84714ed-6015-4bba-910b-01ae323901b2)

<br>

## 💬리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
    - 회색 계열의 CSS 클래스명을 일관성 있게 grey-로 변경하여 전체적인 색상 스타일을 통일했습니다.
    - 버튼, 뱃지, 텍스트, 배경 등 다양한 UI 요소의 색상 스타일이 일부 조정되었습니다.

- **New Features**
    - 사이드시트가 열릴 때 반투명한 검정색 오버레이가 화면 전체에 표시되어, 오버레이 클릭 시 사이드시트가 닫히도록 개선되었습니다.

- **Refactor**
    - 일정 카드에서 오늘 일정에만 적용되던 배경색 강조 효과가 제거되어, 일정 카드의 배경색이 항상 동일하게 표시됩니다.

- **Documentation**
    - "다가오는 일정" 문구가 "다가오는 약속"으로 변경되어 보다 명확한 의미 전달이 이루어집니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->