### PR TITLE
Style/#152 people detail cd

### DIFF
--- a/src/components/contactDetail/ContactPlans.tsx
+++ b/src/components/contactDetail/ContactPlans.tsx
@@ -13,18 +13,29 @@ import { ConfirmToast } from '../toast/ConfirmToast';
 import { useDemoStore } from '@/store/zustand/useDemoStore';
 import { Plus } from '@phosphor-icons/react';
 import { sortPlansByDate } from '@/lib/utils/sortPlansByDate';
+import { usePlanFormStore } from '@/store/zustand/usePlanFormStore';
+import { planFormDefaultValues } from '@/lib/schemas/plansSchema';
 
 interface Props {
   plans: PlanDetailType[] | PlansType[];
+  contactId: string;
 }
 
-const ContactPlans = ({ plans }: Props) => {
+const ContactPlans = ({ plans, contactId }: Props) => {
   const [isAddPlanOpen, setIsAddPlanOpen] = useState(false);
   const [isEditPlanOpen, setIsEditPlanOpen] = useState(false);
   const [selectedPlan, setSelectedPlan] = useState<PlanDetailType | PlansType | null>(null);
+  const { setInitialFormData } = usePlanFormStore();
   const { isDemoUser } = useDemoStore();
-
   const { mutate: deletePlan } = useMutateDeletePlan();
+
+  const addPlanHandler = () => {
+    setInitialFormData({
+      ...planFormDefaultValues,
+      contacts: contactId,
+    });
+    setIsAddPlanOpen(true);
+  };
 
   const editPlanHandler = (plan: PlanDetailType | PlansType) => {
     setSelectedPlan(plan);
@@ -58,37 +69,37 @@ const ContactPlans = ({ plans }: Props) => {
         <h2 className='text-xl font-semibold'>약속 전체보기</h2>
       </div>
 
-    {/* 약속 카드 목록 */}
-    <ul className='grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3'>
-      {/* 약속 추가 버튼 */}
-      <li>
-        <button
-          onClick={() => setIsAddPlanOpen(true)}
-          className='flex h-full w-full flex-col items-center justify-center rounded-lg border-2 border-dashed border-gray-300 bg-white p-6 text-blue-500 transition hover:border-blue-400 hover:bg-blue-50 hover:text-blue-600'
-          style={{ boxShadow: '0 4px 10px rgba(0, 0, 0, 0.1)' }}
-        >
-          <Plus size={28} weight='bold' />
-          <span className='mt-1 text-sm font-medium'>약속 추가</span>
-        </button>
-      </li>
+      {/* 약속 카드 목록 */}
+      <ul className='grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3'>
+        {/* 약속 추가 버튼 */}
+        <li>
+          <button
+            onClick={addPlanHandler}
+            className='flex h-full w-full flex-col items-center justify-center rounded-lg border-2 border-dashed border-gray-300 bg-white p-6 text-blue-500 transition hover:border-blue-400 hover:bg-blue-50 hover:text-blue-600'
+            style={{ boxShadow: '0 4px 10px rgba(0, 0, 0, 0.1)' }}
+          >
+            <Plus size={28} weight='bold' />
+            <span className='mt-1 text-sm font-medium'>약속 추가</span>
+          </button>
+        </li>
 
-      {/* 약속이 있을 경우만 카드 렌더링 */}
-      {plans.length === 0 ? (
-        <li className="col-span-full text-gray-500">등록된 약속이 없습니다.</li>
-      ) : (
-        sortPlansByDate(plans).map((plan) => (
-          <li key={plan.plan_id}>
-            <ContactPlansCard
-              title={plan.title}
-              startDate={plan.start_date}
-              color={plan.colors}
-              onEdit={() => editPlanHandler(plan)}
-              onDelete={() => deletePlanHandler(plan.plan_id)}
-            />
-          </li>
-        ))
-      )}
-    </ul>
+        {/* 약속이 있을 경우만 카드 렌더링 */}
+        {plans.length === 0 ? (
+          <li className='col-span-full text-gray-500'>등록된 약속이 없습니다.</li>
+        ) : (
+          sortPlansByDate(plans).map((plan) => (
+            <li key={plan.plan_id}>
+              <ContactPlansCard
+                title={plan.title}
+                startDate={plan.start_date}
+                color={plan.colors}
+                onEdit={() => editPlanHandler(plan)}
+                onDelete={() => deletePlanHandler(plan.plan_id)}
+              />
+            </li>
+          ))
+        )}
+      </ul>
 
       {/* 사이드 시트 - 약속 추가 */}
       <SideSheet isOpen={isAddPlanOpen} onClose={() => setIsAddPlanOpen(false)} title='약속 추가'>

--- a/src/components/contactDetail/ContactPlans.tsx
+++ b/src/components/contactDetail/ContactPlans.tsx
@@ -8,10 +8,10 @@ import EditPlanForm from '@/components/contactDetail/editPlanForm/EditPlanForm';
 import { EditPlanType, PlansType } from '@/types/plans';
 import { useMutateDeletePlan } from '@/hooks/mutations/useMutateDeletePlan';
 import { toast } from 'react-toastify';
-import { Button } from '@/components/ui/button';
 import PlanForm from '@/components/plans/PlanForm';
 import { ConfirmToast } from '../toast/ConfirmToast';
 import { useDemoStore } from '@/store/zustand/useDemoStore';
+import { Plus } from '@phosphor-icons/react';
 
 interface Props {
   plans: PlanDetailType[] | PlansType[];
@@ -55,9 +55,6 @@ const ContactPlans = ({ plans }: Props) => {
       {/* 타이틀 & 추가 버튼 라인 */}
       <div className='mb-4 flex items-center gap-12'>
         <h2 className='text-xl font-semibold'>약속 전체보기</h2>
-        <Button variant='outline' size='sm' onClick={() => setIsAddPlanOpen(true)}>
-          약속 추가
-        </Button>
       </div>
 
       {/* 약속 카드 목록 */}
@@ -65,6 +62,18 @@ const ContactPlans = ({ plans }: Props) => {
         <p>등록된 약속이 없습니다.</p>
       ) : (
         <ul className='grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3'>
+          {/* 약속 추가 버튼 */}
+          <li>
+            <button
+              onClick={() => setIsAddPlanOpen(true)}
+              className='flex h-full w-full flex-col items-center justify-center rounded-lg border-2 border-dashed border-gray-300 bg-white p-6 text-blue-500 transition hover:border-blue-400 hover:bg-blue-50 hover:text-blue-600'
+            >
+              <Plus size={28} weight='bold' />
+              <span className='mt-1 text-sm font-medium'>약속 추가</span>
+            </button>
+          </li>
+
+          {/* 약속 카드 모음 */}
           {plans.map((plan) => (
             <li key={plan.plan_id}>
               <ContactPlansCard
@@ -81,7 +90,7 @@ const ContactPlans = ({ plans }: Props) => {
 
       {/* 사이드 시트 - 약속 추가 */}
       <SideSheet isOpen={isAddPlanOpen} onClose={() => setIsAddPlanOpen(false)} title='약속 추가'>
-        <PlanForm onClose={()=>setIsAddPlanOpen(false)} />
+        <PlanForm onClose={() => setIsAddPlanOpen(false)} />
       </SideSheet>
 
       {/* 사이드 시트 - 약속 수정 */}

--- a/src/components/contactDetail/ContactPlans.tsx
+++ b/src/components/contactDetail/ContactPlans.tsx
@@ -58,37 +58,37 @@ const ContactPlans = ({ plans }: Props) => {
         <h2 className='text-xl font-semibold'>약속 전체보기</h2>
       </div>
 
-      {/* 약속 카드 목록 */}
-      {plans.length === 0 ? (
-        <p>등록된 약속이 없습니다.</p>
-      ) : (
-        <ul className='grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3'>
-          {/* 약속 추가 버튼 */}
-          <li>
-            <button
-              onClick={() => setIsAddPlanOpen(true)}
-              className='flex h-full w-full flex-col items-center justify-center rounded-lg border-2 border-dashed border-gray-300 bg-white p-6 text-blue-500 transition hover:border-blue-400 hover:bg-blue-50 hover:text-blue-600'
-              style={{ boxShadow: '0 4px 10px rgba(0, 0, 0, 0.1)' }}
-            >
-              <Plus size={28} weight='bold' />
-              <span className='mt-1 text-sm font-medium'>약속 추가</span>
-            </button>
-          </li>
+    {/* 약속 카드 목록 */}
+    <ul className='grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3'>
+      {/* 약속 추가 버튼 */}
+      <li>
+        <button
+          onClick={() => setIsAddPlanOpen(true)}
+          className='flex h-full w-full flex-col items-center justify-center rounded-lg border-2 border-dashed border-gray-300 bg-white p-6 text-blue-500 transition hover:border-blue-400 hover:bg-blue-50 hover:text-blue-600'
+          style={{ boxShadow: '0 4px 10px rgba(0, 0, 0, 0.1)' }}
+        >
+          <Plus size={28} weight='bold' />
+          <span className='mt-1 text-sm font-medium'>약속 추가</span>
+        </button>
+      </li>
 
-          {/* 약속 카드 모음 */}
-          {sortPlansByDate(plans).map((plan) => (
-            <li key={plan.plan_id}>
-              <ContactPlansCard
-                title={plan.title}
-                startDate={plan.start_date}
-                color={plan.colors}
-                onEdit={() => editPlanHandler(plan)}
-                onDelete={() => deletePlanHandler(plan.plan_id)}
-              />
-            </li>
-          ))}
-        </ul>
+      {/* 약속이 있을 경우만 카드 렌더링 */}
+      {plans.length === 0 ? (
+        <li className="col-span-full text-gray-500">등록된 약속이 없습니다.</li>
+      ) : (
+        sortPlansByDate(plans).map((plan) => (
+          <li key={plan.plan_id}>
+            <ContactPlansCard
+              title={plan.title}
+              startDate={plan.start_date}
+              color={plan.colors}
+              onEdit={() => editPlanHandler(plan)}
+              onDelete={() => deletePlanHandler(plan.plan_id)}
+            />
+          </li>
+        ))
       )}
+    </ul>
 
       {/* 사이드 시트 - 약속 추가 */}
       <SideSheet isOpen={isAddPlanOpen} onClose={() => setIsAddPlanOpen(false)} title='약속 추가'>

--- a/src/components/contactDetail/ContactPlans.tsx
+++ b/src/components/contactDetail/ContactPlans.tsx
@@ -51,8 +51,6 @@ const ContactPlans = ({ plans }: Props) => {
     });
   };
 
-  const sortedPlans = sortPlansByDate(plans);
-
   return (
     <div>
       {/* 타이틀 & 추가 버튼 라인 */}
@@ -78,7 +76,7 @@ const ContactPlans = ({ plans }: Props) => {
           </li>
 
           {/* 약속 카드 모음 */}
-          {sortedPlans.map((plan) => (
+          {sortPlansByDate(plans).map((plan) => (
             <li key={plan.plan_id}>
               <ContactPlansCard
                 title={plan.title}

--- a/src/components/contactDetail/ContactPlans.tsx
+++ b/src/components/contactDetail/ContactPlans.tsx
@@ -12,6 +12,7 @@ import PlanForm from '@/components/plans/PlanForm';
 import { ConfirmToast } from '../toast/ConfirmToast';
 import { useDemoStore } from '@/store/zustand/useDemoStore';
 import { Plus } from '@phosphor-icons/react';
+import { sortPlansByDate } from '@/lib/utils/sortPlansByDate';
 
 interface Props {
   plans: PlanDetailType[] | PlansType[];
@@ -50,6 +51,8 @@ const ContactPlans = ({ plans }: Props) => {
     });
   };
 
+  const sortedPlans = sortPlansByDate(plans);
+
   return (
     <div>
       {/* 타이틀 & 추가 버튼 라인 */}
@@ -67,6 +70,7 @@ const ContactPlans = ({ plans }: Props) => {
             <button
               onClick={() => setIsAddPlanOpen(true)}
               className='flex h-full w-full flex-col items-center justify-center rounded-lg border-2 border-dashed border-gray-300 bg-white p-6 text-blue-500 transition hover:border-blue-400 hover:bg-blue-50 hover:text-blue-600'
+              style={{ boxShadow: '0 4px 10px rgba(0, 0, 0, 0.1)' }}
             >
               <Plus size={28} weight='bold' />
               <span className='mt-1 text-sm font-medium'>약속 추가</span>
@@ -74,7 +78,7 @@ const ContactPlans = ({ plans }: Props) => {
           </li>
 
           {/* 약속 카드 모음 */}
-          {plans.map((plan) => (
+          {sortedPlans.map((plan) => (
             <li key={plan.plan_id}>
               <ContactPlansCard
                 title={plan.title}

--- a/src/components/contactDetail/ContactProfile.tsx
+++ b/src/components/contactDetail/ContactProfile.tsx
@@ -26,7 +26,7 @@ const ContactProfile = ({ contact, plans, onDeleteSuccess }: Props) => {
 
   const deleteContactHandler = () => {
     if (isDemoUser) {
-      toast.info('데모체험중에는 제한된 기능입니다.')
+      toast.info('데모체험중에는 제한된 기능입니다.');
       return;
     }
     ConfirmToast({
@@ -86,12 +86,25 @@ const ContactProfile = ({ contact, plans, onDeleteSuccess }: Props) => {
         </div>
 
         {/* 우측 버튼 */}
-        <div className='space-x-2'>
-          <Button variant='outline' size='sm' onClick={() => setIsEditContactOpen(true)}>
-            <PencilSimple size={16} />내 사람 수정
+        <div className='flex items-center gap-3 pt-[3.8rem]'>
+          {/* 수정 버튼 */}
+          <Button
+            variant='ghost'
+            size='sm'
+            className='h-9 rounded-md border border-blue-500 px-4 text-sm font-semibold text-blue-600 transition hover:bg-blue-50 hover:shadow-sm'
+            onClick={() => setIsEditContactOpen(true)}
+          >
+            <PencilSimple size={16} className='mr-2' />내 사람 수정
           </Button>
-          <Button variant='destructive' size='sm' onClick={deleteContactHandler}>
-            <Trash size={16} />내 사람 삭제
+
+          {/* 삭제 버튼 */}
+          <Button
+            variant='ghost'
+            size='sm'
+            className='h-9 rounded-md border border-gray-300 px-4 text-sm font-semibold text-gray-700 transition hover:bg-gray-100 hover:shadow-sm'
+            onClick={deleteContactHandler}
+          >
+            <Trash size={16} className='mr-2' />내 사람 삭제
           </Button>
         </div>
       </div>

--- a/src/components/contactDetail/ContactProfile.tsx
+++ b/src/components/contactDetail/ContactProfile.tsx
@@ -12,6 +12,7 @@ import { PencilSimple, Trash } from '@phosphor-icons/react';
 import { useDemoStore } from '@/store/zustand/useDemoStore';
 import { PlansType } from '@/types/plans';
 import { mutateDeletePlan } from '@/app/api/supabase/service';
+import { sortPlansByDate } from '@/lib/utils/sortPlansByDate';
 
 interface Props {
   contact: ContactDetailType;
@@ -141,7 +142,7 @@ const ContactProfile = ({ contact, plans, onDeleteSuccess }: Props) => {
           <div className='w-full md:w-1/2'>
             <h2 className='mb-4 text-xl font-bold text-gray-800'>다가오는 약속</h2>
             <div className='grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-2 xl:grid-cols-2'>
-              {plans.map((plan) => (
+              {sortPlansByDate(plans).map((plan) => (
                 <ContactPlansCard
                   key={plan.plan_id}
                   title={plan.title}

--- a/src/components/contactDetail/PeopleDetailPanel.tsx
+++ b/src/components/contactDetail/PeopleDetailPanel.tsx
@@ -36,7 +36,7 @@ const PeopleDetailPanel = ({ contactsId, onDeleteSuccess }: Props) => {
   return (
     <div className='container mx-auto px-4 pt-8'>
       <Tabs tabs={['내사람정보', '약속']}>
-        {[<ContactProfile key='profile' contact={contact} plans={plans} onDeleteSuccess={onDeleteSuccess} />, <ContactPlans key='plans' plans={plans} />]}
+        {[<ContactProfile key='profile' contact={contact} plans={plans} onDeleteSuccess={onDeleteSuccess} />, <ContactPlans key='plans' plans={plans} contactId={contact.contacts_id} />]}
       </Tabs>
     </div>
   );

--- a/src/lib/utils/sortPlansByDate.ts
+++ b/src/lib/utils/sortPlansByDate.ts
@@ -1,0 +1,20 @@
+import { PlanDetailType } from '@/types/contacts';
+import { PlansType } from '@/types/plans';
+import { differenceInCalendarDays } from 'date-fns';
+
+export function sortPlansByDate(plans: (PlansType | PlanDetailType)[]): (PlansType | PlanDetailType)[] {
+  const today = new Date();
+
+  const getSortValue = (dDay: number) => {
+    if (dDay < 0) return 1000 + dDay; // D+
+    if (dDay === 0) return 1500; // D-Day
+    return 2000 + dDay; // D-
+  };
+
+  return plans.slice().sort((a, b) => {
+    const dDayA = differenceInCalendarDays(new Date(a.start_date), today);
+    const dDayB = differenceInCalendarDays(new Date(b.start_date), today);
+
+    return getSortValue(dDayA) - getSortValue(dDayB);
+  });
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- ex) #152 

<br>

## 📝 작업 내용

> 내 사람 수정, 삭제 버튼 UI 수정
> 약속 추가 UI 변
> 약속 카드 날짜 기준으로 정렬
> 약속 추가 시 내 사람 초기값 세팅하도록 개선(약속 수정도 개선할 계획입니다.)

<br>

![스크린샷 2025-04-25 181300](https://github.com/user-attachments/assets/05bfacbf-b545-4489-8bdc-c8d7474d6f5c)
![스크린샷 2025-04-25 181310](https://github.com/user-attachments/assets/d53c00a6-c67c-4847-a1e4-f8464d14ec80)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 연락처별로 플랜 추가 시 연락처 ID가 자동으로 반영되도록 개선되었습니다.
	- 플랜 목록이 날짜 기준으로 정렬되어 표시됩니다.
- **스타일**
	- 플랜 추가 버튼이 목록 상단에 고정되어 더 쉽게 접근할 수 있습니다.
	- 연락처 프로필의 편집 및 삭제 버튼 디자인이 개선되었습니다.
- **버그 수정**
	- 플랜이 없을 때 안내 메시지의 표시 위치와 스타일이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->