### PR TITLE
Hotfix fetchCalendarPlans에서 사용자에 따라 이벤트 가져오기 로직 수정

### DIFF
--- a/src/app/(pages)/(nav)/calendar/page.tsx
+++ b/src/app/(pages)/(nav)/calendar/page.tsx
@@ -233,7 +233,7 @@ export default function Calendar() {
       colors: '#2F80ED', // 기본 색상
     })),
   ];
-
+ 
   // 프리페칭 함수 (hover 시 호출)
   const prefetchCalendarPlans = async (action: 'NEXT' | 'PREV' | 'TODAY' | 'DATE') => {
     if (!user && !isDemoUser) return;
@@ -242,10 +242,10 @@ export default function Calendar() {
     const newDate = calculateNewDate(moment, action);
     const newYear = newDate.getFullYear();
     const newMonth = newDate.getMonth() + 1;
-
+    const calendarUser = isDemoUser ? demoUser : user;
     await queryClient.prefetchQuery({
       queryKey: [QUERY_KEY.PLANS, user?.id, newYear, newMonth],
-      queryFn: () => fetchCalendarPlans({ user, year: newYear, date: newDate }),
+      queryFn: () => fetchCalendarPlans({ user: calendarUser, year: newYear, date: newDate }),
       staleTime: 5 * 60 * 1000, // 5분 동안은 fresh
     });
   };

--- a/src/lib/utils/fetchCalendarPlans.ts
+++ b/src/lib/utils/fetchCalendarPlans.ts
@@ -1,4 +1,5 @@
 import { getMonthlyPlans } from '@/app/api/supabase/service';
+import { useDemoStore } from '@/store/zustand/useDemoStore';
 import { CalendarEventType, PlansType } from '@/types/plans';
 import { User } from '@supabase/supabase-js';
 
@@ -11,17 +12,27 @@ export const fetchCalendarPlans = async ({
   year: number;
   date: Date;
 }): Promise<CalendarEventType[]> => {
+  const { isDemoUser, demoPlans } = useDemoStore.getState();
+
   const month = date.getMonth() + 1; // Date 객체에서 month 추출
 
   const plans: PlansType[] = await getMonthlyPlans(user, year, month);
-
-  const events: CalendarEventType[] = plans.map((plan) => ({
+  
+  const demoEvents = demoPlans.map((plan) => ({
     id: plan.plan_id,
     title: plan.title,
     start: new Date(plan.start_date),
     end: new Date(plan.end_date),
     colors: plan.colors,
   }));
-
+  
+  const trueEvents: CalendarEventType[] = plans.map((plan) => ({
+    id: plan.plan_id,
+    title: plan.title,
+    start: new Date(plan.start_date),
+    end: new Date(plan.end_date),
+    colors: plan.colors,
+  }));
+  const events = isDemoUser ? demoEvents : trueEvents;
   return events;
 };


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- ex) #이슈번호, #이슈번호

<br>

## 📝 작업 내용

> 데모버전에서 캘린더 월 이동 시 생기던 문제를 해결했습니다.
1. 월 이동시 에러가 발생되던 것
2. 월 이동후 오늘날짜로 돌아오면 데이터가 로드되지 않던 것 

<br>

## 🖼 스크린샷

<br>

## 💬리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 데모 사용자일 경우, 캘린더에서 데모 일정 데이터를 표시하도록 개선되었습니다.

- **버그 수정**
  - 캘린더 일정이 데모 사용자와 일반 사용자에 따라 올바르게 분리되어 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->